### PR TITLE
Apply VerbumFlow brand guidelines — full UI redesign

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,11 +1,11 @@
 {
-  "name": "Verbarium — French Conjugation Practice",
-  "short_name": "Verbarium",
+  "name": "VerbumFlow — French Conjugation Practice",
+  "short_name": "VerbumFlow",
   "description": "Master French verb conjugations with interactive flashcards",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#6366f1",
-  "theme_color": "#6366f1",
+  "background_color": "#0B1020",
+  "theme_color": "#0B1020",
   "orientation": "portrait-primary",
   "icons": [
     {

--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -240,7 +240,6 @@ export function ConjugationPractice({
     const newStreak = isCorrect ? streak + 1 : 0;
     setStreak(newStreak);
 
-    // Persist to Firestore if signed in
     if (user) {
       recordAnswer(user.uid, isCorrect, newStreak)
         .then((updates) => {
@@ -282,24 +281,30 @@ export function ConjugationPractice({
     if (userAnswer) handleAnswer(userAnswer);
   };
 
-  const getButtonClass = (option: string) => {
-    if (!isAnswered) return "secondary";
+  const getButtonBrandClass = (option: string): string => {
+    if (!isAnswered) {
+      return "bg-white text-[#0B1020] border border-gray-200 hover:border-[#1F4BFF] hover:text-[#1F4BFF] hover:bg-blue-50";
+    }
     const isCorrectAnswer = option === currentQuestion?.correctAnswer;
     const isUserChoice = option === userAnswer;
 
-    if (isCorrectAnswer) return "success";
-    if (isUserChoice && !isCorrectAnswer) return "destructive";
-
-    return "secondary";
+    if (isCorrectAnswer) {
+      return "bg-[#1F4BFF] text-white border-[#1F4BFF] hover:bg-[#1637CC] disabled:opacity-100";
+    }
+    if (isUserChoice && !isCorrectAnswer) {
+      return "bg-[#FF6A4D] text-white border-[#FF6A4D] hover:bg-[#D95A3F] disabled:opacity-100";
+    }
+    return "bg-white text-[#0B1020] border border-gray-200 opacity-50";
   };
 
   const getInputClass = () => {
-    if (!isAnswered) return "bg-white/80";
+    if (!isAnswered)
+      return "bg-[#FAFAF7] border-gray-200 focus-visible:ring-[#1F4BFF] focus-visible:border-[#0B1020]";
     if (feedback === "correct")
-      return "bg-green-200 border-green-500 focus-visible:ring-green-500";
+      return "bg-green-100 border-green-500 focus-visible:ring-green-500";
     if (feedback === "incorrect")
-      return "bg-red-200 border-red-500 focus-visible:ring-red-500";
-    return "bg-white/80";
+      return "bg-red-100 border-red-500 focus-visible:ring-red-500";
+    return "bg-[#FAFAF7]";
   };
 
   const displayPronoun =
@@ -313,7 +318,7 @@ export function ConjugationPractice({
         <Flame
           className={cn(
             "transition-colors",
-            streak > 0 ? "text-orange-400" : "text-white/50"
+            streak > 0 ? "text-[#FF6A4D]" : "text-white/50"
           )}
         />
         <span>{streak}</span>
@@ -322,21 +327,42 @@ export function ConjugationPractice({
         <Card
           key={key}
           className={cn(
-            "relative overflow-hidden transition-all duration-300 animate-in fade-in-0 zoom-in-95 bg-white/80 backdrop-blur-sm shadow-xl",
+            "relative overflow-hidden transition-all duration-300 animate-in fade-in-0 zoom-in-95 shadow-xl",
             feedback === "incorrect" && "animate-shake"
           )}
+          style={{
+            backgroundColor: "#FAFAF7",
+            border: "1px solid rgba(31,75,255,0.12)",
+          }}
         >
           <CardHeader>
-            <CardTitle className="text-3xl sm:text-4xl text-center font-bold text-gray-800">
+            <CardTitle
+              className="text-3xl sm:text-4xl text-center font-extrabold"
+              style={{
+                color: "#0B1020",
+                fontFamily: "'Plus Jakarta Sans', sans-serif",
+              }}
+            >
               {currentQuestion.verb}
             </CardTitle>
             <CardDescription className="text-center">
-              <Badge variant="secondary" className="bg-gray-200 text-gray-700">
+              <Badge
+                variant="secondary"
+                className="text-xs font-semibold"
+                style={{
+                  backgroundColor: "rgba(31,75,255,0.08)",
+                  color: "#1F4BFF",
+                }}
+              >
                 {currentQuestion.tense}
               </Badge>
               <Badge
                 variant="secondary"
-                className="ml-2 bg-gray-200 text-gray-700"
+                className="ml-2 text-xs font-semibold"
+                style={{
+                  backgroundColor: "rgba(31,75,255,0.08)",
+                  color: "#1F4BFF",
+                }}
               >
                 {displayPronoun}
               </Badge>
@@ -349,19 +375,11 @@ export function ConjugationPractice({
                   <div key={option}>
                     <Button
                       type="button"
-                      variant={getButtonClass(option)}
                       onClick={() => handleAnswer(option)}
                       disabled={isAnswered}
                       className={cn(
-                        "h-auto py-4 text-base sm:text-lg justify-center w-full text-center whitespace-normal shadow-md",
-                        {
-                          "hover:bg-green-600":
-                            getButtonClass(option) === "success",
-                          "hover:bg-red-700":
-                            getButtonClass(option) === "destructive",
-                          "bg-white text-gray-800 hover:bg-gray-100":
-                            getButtonClass(option) === "secondary",
-                        }
+                        "h-auto py-4 text-base sm:text-lg justify-center w-full text-center whitespace-normal shadow-sm",
+                        getButtonBrandClass(option)
                       )}
                     >
                       {option}
@@ -394,10 +412,7 @@ export function ConjugationPractice({
                   onChange={(e) => setUserAnswer(e.target.value)}
                   disabled={isAnswered}
                   placeholder="Type the conjugation..."
-                  className={cn(
-                    "text-center text-lg h-14",
-                    getInputClass()
-                  )}
+                  className={cn("text-center text-lg h-14", getInputClass())}
                   autoCapitalize="none"
                   autoComplete="off"
                   autoCorrect="off"
@@ -417,7 +432,7 @@ export function ConjugationPractice({
                 {!isAnswered && (
                   <Button
                     type="submit"
-                    className="w-full bg-blue-500 hover:bg-blue-600 text-white"
+                    className="w-full bg-[#1F4BFF] hover:bg-[#1637CC] text-white"
                   >
                     Check
                   </Button>
@@ -438,7 +453,7 @@ export function ConjugationPractice({
             {isAnswered && (
               <Button
                 onClick={prepareNextStage}
-                className="gap-2 animate-in fade-in-50 bg-blue-500 hover:bg-blue-600 text-white"
+                className="gap-2 animate-in fade-in-50 bg-[#1F4BFF] hover:bg-[#1637CC] text-white"
               >
                 Next <ArrowRight className="h-4 w-4" />
               </Button>
@@ -446,9 +461,17 @@ export function ConjugationPractice({
           </CardFooter>
         </Card>
       ) : (
-        <Card className="flex flex-col items-center justify-center p-12 text-center bg-white/80 backdrop-blur-sm shadow-xl">
-          <div className="h-16 w-16 border-4 border-dashed rounded-full animate-spin border-primary"></div>
-          <CardTitle className="mt-4">Loading Verbs...</CardTitle>
+        <Card
+          className="flex flex-col items-center justify-center p-12 text-center shadow-xl"
+          style={{
+            backgroundColor: "#FAFAF7",
+            border: "1px solid rgba(31,75,255,0.12)",
+          }}
+        >
+          <div className="h-16 w-16 border-4 border-dashed rounded-full animate-spin border-[#1F4BFF]"></div>
+          <CardTitle className="mt-4" style={{ color: "#0B1020" }}>
+            Loading Verbs...
+          </CardTitle>
           <CardDescription className="mt-2">
             Get ready to practice!
           </CardDescription>

--- a/src/app/components/leaderboard.tsx
+++ b/src/app/components/leaderboard.tsx
@@ -57,7 +57,7 @@ function LeaderboardList({
           className={cn(
             "flex items-center gap-3 p-3 rounded-lg transition-colors",
             entry.uid === currentUid
-              ? "bg-blue-50 border border-blue-200"
+              ? "bg-[rgba(31,75,255,0.06)] border border-[#1F4BFF]"
               : "bg-gray-50 hover:bg-gray-100"
           )}
         >
@@ -87,7 +87,7 @@ function LeaderboardList({
             <p className="text-sm font-medium truncate">
               {entry.displayName}
               {entry.uid === currentUid && (
-                <Badge variant="secondary" className="ml-2 text-[10px] py-0">
+                <Badge className="ml-2 text-[10px] py-0 bg-[#1F4BFF] text-white hover:bg-[#1F4BFF]">
                   You
                 </Badge>
               )}
@@ -143,7 +143,7 @@ export function Leaderboard({ open, onOpenChange }: LeaderboardProps) {
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Trophy className="h-5 w-5 text-yellow-500" />
+            <Trophy className="h-5 w-5 text-[#FF6A4D]" />
             Leaderboard
           </DialogTitle>
         </DialogHeader>
@@ -155,13 +155,13 @@ export function Leaderboard({ open, onOpenChange }: LeaderboardProps) {
         ) : (
           <Tabs defaultValue="streak">
             <TabsList className="grid w-full grid-cols-3">
-              <TabsTrigger value="streak" className="text-xs gap-1">
+              <TabsTrigger value="streak" className="text-xs gap-1 data-[state=active]:text-[#1F4BFF]">
                 <Flame className="h-3 w-3" /> Best Streak
               </TabsTrigger>
-              <TabsTrigger value="correct" className="text-xs gap-1">
+              <TabsTrigger value="correct" className="text-xs gap-1 data-[state=active]:text-[#1F4BFF]">
                 <Target className="h-3 w-3" /> Total ✓
               </TabsTrigger>
-              <TabsTrigger value="daily" className="text-xs gap-1">
+              <TabsTrigger value="daily" className="text-xs gap-1 data-[state=active]:text-[#1F4BFF]">
                 <Calendar className="h-3 w-3" /> Daily
               </TabsTrigger>
             </TabsList>

--- a/src/app/components/user-menu.tsx
+++ b/src/app/components/user-menu.tsx
@@ -35,7 +35,7 @@ export function UserMenu({ onShowLeaderboard }: UserMenuProps) {
           onClick={onShowLeaderboard}
           variant="ghost"
           size="icon"
-          className="text-white hover:bg-white/20"
+          className="text-white hover:bg-white/10"
           title="Leaderboard"
         >
           <Trophy className="h-5 w-5" />
@@ -43,7 +43,7 @@ export function UserMenu({ onShowLeaderboard }: UserMenuProps) {
         <Button
           onClick={signInWithGoogle}
           variant="ghost"
-          className="text-white hover:bg-white/20 gap-2"
+          className="text-white hover:bg-white/10 gap-2"
         >
           <LogIn className="h-4 w-4" />
           <span className="hidden sm:inline">Sign in</span>
@@ -58,7 +58,7 @@ export function UserMenu({ onShowLeaderboard }: UserMenuProps) {
         onClick={onShowLeaderboard}
         variant="ghost"
         size="icon"
-        className="text-white hover:bg-white/20"
+        className="text-white hover:bg-white/10"
         title="Leaderboard"
       >
         <Trophy className="h-5 w-5" />
@@ -67,9 +67,9 @@ export function UserMenu({ onShowLeaderboard }: UserMenuProps) {
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
-            className="relative h-10 w-10 rounded-full p-0 hover:bg-white/20"
+            className="relative h-10 w-10 rounded-full p-0 hover:bg-white/10"
           >
-            <Avatar className="h-9 w-9 border-2 border-white/50">
+            <Avatar className="h-9 w-9 border-2 border-white/30">
               <AvatarImage
                 src={user?.photoURL ?? undefined}
                 alt={user?.displayName ?? "User"}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,14 +1,18 @@
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700;800&family=JetBrains+Mono&display=swap');
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-body {
-  font-family: Arial, Helvetica, sans-serif;
-}
-
 @layer base {
   :root {
+    --blue: #1F4BFF;
+    --coral: #FF6A4D;
+    --ink: #0B1020;
+    --paper: #FAFAF7;
+    --font-display: 'Plus Jakarta Sans', sans-serif;
+    --font-mono: 'JetBrains Mono', monospace;
+
     --background: 210 20% 98%;
     --foreground: 224 71% 4%;
     --card: 0 0% 100%;
@@ -84,6 +88,7 @@ body {
     @apply border-border;
   }
   body {
+    font-family: var(--font-display);
     @apply bg-background text-foreground;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,11 +6,11 @@ import { cn } from "@/lib/utils";
 import { AuthProvider } from "@/contexts/auth-context";
 
 export const metadata: Metadata = {
-  title: "Verbarium — French Conjugation Practice",
+  title: "VerbumFlow — French Conjugation Practice",
   description:
     "Master French verb conjugations with interactive flashcards. Practice présent, imparfait, futur, passé composé and more.",
   manifest: "/manifest.json",
-  themeColor: "#6366f1",
+  themeColor: "#0B1020",
   viewport: "width=device-width, initial-scale=1, maximum-scale=1",
 };
 
@@ -22,16 +22,6 @@ export default function RootLayout({
   return (
     <html lang="en" className="h-full">
       <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
-          rel="stylesheet"
-        />
         <link rel="apple-touch-icon" href="/icons/icon-192.png" />
       </head>
       <body className={cn("font-body antialiased h-full")}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,40 +5,16 @@ import { ConjugationPractice } from "@/app/components/conjugation-practice";
 import { UserMenu } from "@/app/components/user-menu";
 import { Leaderboard } from "@/app/components/leaderboard";
 import { useAuth } from "@/contexts/auth-context";
-import { cn } from "@/lib/utils";
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { initializeUserStats, type UserStats } from "@/lib/firestore";
 import { Badge } from "@/components/ui/badge";
 import { Calendar, Target, Heart } from "lucide-react";
 
-const gradients = [
-  "from-pink-300 via-purple-300 to-indigo-400",
-  "from-green-200 via-green-300 to-blue-500",
-  "from-yellow-200 via-red-200 to-pink-200",
-  "from-indigo-300 to-purple-400",
-  "from-green-200 to-green-500",
-  "from-red-200 to-yellow-200",
-  "from-blue-100 via-blue-300 to-blue-500",
-  "from-purple-200 via-purple-400 to-purple-800",
-];
-
 export default function Home() {
-  const [backgroundClass, setBackgroundClass] = useState("");
   const [showLeaderboard, setShowLeaderboard] = useState(false);
   const [userStats, setUserStats] = useState<UserStats | null>(null);
   const { user } = useAuth();
 
-  const changeBackground = React.useCallback(() => {
-    const randomGradient =
-      gradients[Math.floor(Math.random() * gradients.length)];
-    setBackgroundClass(randomGradient);
-  }, []);
-
-  useEffect(() => {
-    changeBackground();
-  }, [changeBackground]);
-
-  // Initialize user stats on sign-in
   useEffect(() => {
     if (user) {
       initializeUserStats(
@@ -53,10 +29,11 @@ export default function Home() {
 
   return (
     <main
-      className={cn(
-        "flex min-h-screen w-full flex-col items-center justify-center p-4 sm:p-6 lg:p-8 transition-all duration-1000 ease-in-out bg-gradient-to-br",
-        backgroundClass
-      )}
+      className="flex min-h-screen w-full flex-col items-center justify-center p-4 sm:p-6 lg:p-8"
+      style={{
+        background:
+          "radial-gradient(ellipse at 0% 0%, rgba(31,75,255,0.15) 0%, transparent 50%), radial-gradient(ellipse at 100% 100%, rgba(255,106,77,0.15) 0%, transparent 50%), #0B1020",
+      }}
     >
       {/* Top bar */}
       <div className="absolute top-4 right-4 z-10">
@@ -84,16 +61,74 @@ export default function Home() {
       )}
 
       <div className="w-full max-w-md">
-        <header className="text-center mb-4">
-          <h1 className="text-5xl sm:text-6xl font-bold tracking-tight text-white drop-shadow-md">
-            Verbarium
-          </h1>
-          <p className="mt-2 text-base text-white/90 drop-shadow-sm">
-            Master French verb conjugations with interactive flashcards.
+        <header className="text-center mb-6">
+          {/* Brand mark + wordmark */}
+          <div className="flex items-center justify-center gap-3 mb-2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 300 280"
+              className="h-10 sm:h-12 w-auto flex-shrink-0"
+              aria-hidden="true"
+            >
+              <g transform="translate(40 40)">
+                <defs>
+                  <linearGradient
+                    id="vf-mark-header"
+                    x1="25"
+                    x2="185"
+                    y1="0"
+                    y2="0"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop offset="50%" stopColor="#FF6A4D" />
+                    <stop offset="50%" stopColor="#1F4BFF" />
+                  </linearGradient>
+                </defs>
+                <path
+                  d="M40 50 L105 160 L170 50"
+                  fill="none"
+                  stroke="#FFFFFF"
+                  strokeWidth="22"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M25 100 Q70 70 105 100 T185 100"
+                  fill="none"
+                  stroke="url(#vf-mark-header)"
+                  strokeWidth="14"
+                  strokeLinecap="round"
+                />
+              </g>
+            </svg>
+            {/* Wordmark */}
+            <span
+              className="text-4xl sm:text-5xl"
+              style={{
+                fontFamily: "'Plus Jakarta Sans', sans-serif",
+                letterSpacing: "-2px",
+                lineHeight: 1,
+              }}
+            >
+              <span className="font-bold text-white">verbum</span>
+              <span style={{ fontWeight: 800, color: "#FF6A4D" }}>flow</span>
+            </span>
+          </div>
+          {/* Tagline */}
+          <p
+            className="text-xs text-white uppercase"
+            style={{
+              fontFamily: "'JetBrains Mono', monospace",
+              letterSpacing: "4px",
+              opacity: 0.6,
+            }}
+          >
+            LEARN AND COMPETE
           </p>
         </header>
+
         <ConjugationPractice
-          onNextQuestion={changeBackground}
+          onNextQuestion={() => {}}
           onStatsUpdate={setUserStats}
         />
       </div>
@@ -113,10 +148,7 @@ export default function Home() {
       </footer>
 
       {/* Leaderboard modal */}
-      <Leaderboard
-        open={showLeaderboard}
-        onOpenChange={setShowLeaderboard}
-      />
+      <Leaderboard open={showLeaderboard} onOpenChange={setShowLeaderboard} />
     </main>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,8 +11,9 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        body: ['Inter', 'sans-serif'],
-        headline: ['Inter', 'sans-serif'],
+        body: ["'Plus Jakarta Sans'", 'sans-serif'],
+        headline: ["'Plus Jakarta Sans'", 'sans-serif'],
+        mono: ["'JetBrains Mono'", 'monospace'],
         code: ['monospace'],
       },
       colors: {


### PR DESCRIPTION
Applies the VerbumFlow brand identity across all UI files as specified in issue #7.

**Changes:**
- Static Deep Ink background with radial blue/coral glows (replaces random gradients)
- Inline SVG logo mark + verbumflow wordmark + JetBrains Mono tagline
- Plus Jakarta Sans loaded via CSS @import, brand CSS variables in globals.css
- Paper (#FAFAF7) conjugation card with Electric Blue border
- Brand-colored badges, buttons, streak flame, and input field
- Leaderboard: Coral trophy, Electric Blue tabs/row/"You" badge
- Manifest: Deep Ink theme color, VerbumFlow name

Closes #7

Generated with [Claude Code](https://claude.ai/code)