### PR TITLE
feat: UI polish — favicon, larger mark, streak label

### DIFF
--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -314,14 +314,24 @@ export function ConjugationPractice({
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-center items-center gap-2 text-white font-bold text-xl drop-shadow-md">
-        <Flame
-          className={cn(
-            "transition-colors",
-            streak > 0 ? "text-[#FF6A4D]" : "text-white/50"
-          )}
-        />
-        <span>{streak}</span>
+      <div className="flex flex-col items-center justify-center gap-1 mb-1">
+        <div className="flex items-center gap-2 text-white font-bold text-xl drop-shadow-md">
+          <Flame
+            className={cn(
+              "transition-colors",
+              streak > 0 ? "text-[#FF6A4D]" : "text-white/30"
+            )}
+          />
+          <span>{streak}</span>
+        </div>
+        {user && (
+          <p
+            className="text-white/50 text-[10px] uppercase tracking-widest"
+            style={{ fontFamily: "'JetBrains Mono', monospace" }}
+          >
+            {streak === 0 ? "start your streak" : "keep it going"}
+          </p>
+        )}
       </div>
       {currentQuestion ? (
         <Card

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,6 +23,9 @@ export default function RootLayout({
     <html lang="en" className="h-full">
       <head>
         <link rel="apple-touch-icon" href="/icons/icon-192.png" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/brand/icon/icon-blue-32.png" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/brand/icon/icon-blue-16.png" />
+        <link rel="shortcut icon" href="/brand/icon/icon-blue-32.png" />
       </head>
       <body className={cn("font-body antialiased h-full")}>
         <AuthProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,65 +62,64 @@ export default function Home() {
 
       <div className="w-full max-w-md">
         <header className="text-center mb-6">
-          {/* Brand mark + wordmark */}
-          <div className="flex items-center justify-center gap-3 mb-2">
+          {/* Brand mark — centered, standalone */}
+          <div className="flex justify-center mb-3">
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 300 280"
-              className="h-10 sm:h-12 w-auto flex-shrink-0"
+              viewBox="0 0 220 200"
+              className="h-16 sm:h-20 w-auto"
               aria-hidden="true"
             >
-              <g transform="translate(40 40)">
-                <defs>
-                  <linearGradient
-                    id="vf-mark-header"
-                    x1="25"
-                    x2="185"
-                    y1="0"
-                    y2="0"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop offset="50%" stopColor="#FF6A4D" />
-                    <stop offset="50%" stopColor="#1F4BFF" />
-                  </linearGradient>
-                </defs>
-                <path
-                  d="M40 50 L105 160 L170 50"
-                  fill="none"
-                  stroke="#FFFFFF"
-                  strokeWidth="22"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M25 100 Q70 70 105 100 T185 100"
-                  fill="none"
-                  stroke="url(#vf-mark-header)"
-                  strokeWidth="14"
-                  strokeLinecap="round"
-                />
-              </g>
+              <defs>
+                <linearGradient
+                  id="vf-mark-header"
+                  x1="25" x2="185" y1="0" y2="0"
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop offset="50%" stopColor="#FF6A4D" />
+                  <stop offset="50%" stopColor="#1F4BFF" />
+                </linearGradient>
+              </defs>
+              <path
+                d="M40 50 L105 160 L170 50"
+                fill="none"
+                stroke="#FFFFFF"
+                strokeWidth="22"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M25 100 Q70 70 105 100 T185 100"
+                fill="none"
+                stroke="url(#vf-mark-header)"
+                strokeWidth="14"
+                strokeLinecap="round"
+              />
             </svg>
-            {/* Wordmark */}
+          </div>
+
+          {/* Wordmark — centered below the mark */}
+          <div className="flex justify-center mb-1">
             <span
-              className="text-4xl sm:text-5xl"
               style={{
                 fontFamily: "'Plus Jakarta Sans', sans-serif",
                 letterSpacing: "-2px",
                 lineHeight: 1,
               }}
+              className="text-4xl sm:text-5xl"
             >
               <span className="font-bold text-white">verbum</span>
               <span style={{ fontWeight: 800, color: "#FF6A4D" }}>flow</span>
             </span>
           </div>
+
           {/* Tagline */}
           <p
             className="text-xs text-white uppercase"
             style={{
               fontFamily: "'JetBrains Mono', monospace",
               letterSpacing: "4px",
-              opacity: 0.6,
+              opacity: 0.5,
             }}
           >
             LEARN AND COMPETE


### PR DESCRIPTION
Closes #9

Three surgical UI fixes:
- Add brand favicon (32x32, 16x16, shortcut) in layout.tsx
- Redesign header: larger standalone SVG mark (h-16/h-20) above centered wordmark
- Add motivational label below streak counter for signed-in users

Generated with [Claude Code](https://claude.ai/code)