### PR TITLE
UI Polish Batch 3: icon bar, fullscreen, centering, answer colors, ghost bug

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "VerbumFlow",
   "description": "Master French verb conjugations with interactive flashcards",
   "start_url": "/",
-  "display": "standalone",
+  "display": "fullscreen",
   "background_color": "#0B1020",
   "theme_color": "#0B1020",
   "orientation": "portrait-primary",

--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -51,6 +51,7 @@ type ConjugationPracticeProps = {
   onStatsUpdate?: React.Dispatch<React.SetStateAction<UserStats | null>>;
   onStreakRecord?: (type: "personal" | "global") => void;
   practiceOnly?: boolean;
+  userStats?: UserStats | null;
 };
 
 const TIMER_DURATION = 15;
@@ -99,6 +100,7 @@ export function ConjugationPractice({
   onStatsUpdate,
   onStreakRecord,
   practiceOnly = false,
+  userStats = null,
 }: ConjugationPracticeProps) {
   const [gameState, setGameState] = useState<GameState>(
     practiceOnly ? "playing" : "idle"
@@ -126,6 +128,8 @@ export function ConjugationPractice({
   const [hasShownLevelUp, setHasShownLevelUp] = useState(false);
   // practiceOnly score
   const [practiceScore, setPracticeScore] = useState(0);
+  // last correct answer — shown in loss overlay
+  const [lastCorrectAnswer, setLastCorrectAnswer] = useState<string | null>(null);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
@@ -383,6 +387,8 @@ export function ConjugationPractice({
     setIsAnswered(true);
     setFeedback("incorrect");
     setIsTimedOut(true);
+    setUserAnswer("");
+    setLastCorrectAnswer(currentQuestion.correctAnswer);
     setLastStreakValue(streak);
     setStreak(0);
     setFillInTheBlankQueue([]);
@@ -456,11 +462,13 @@ export function ConjugationPractice({
     setFeedback(null);
     setIsAnswered(false);
     setIsTimedOut(false);
+    setUserAnswer("");
     setFillInTheBlankQueue([]);
     setMode("multiple-choice");
     setCorrectAnswerCount(0);
     setShowLevelUp(false);
     setHasShownLevelUp(false);
+    setLastCorrectAnswer(null);
   };
 
   const handleSwitchGameMode = (newMode: GameMode) => {
@@ -489,6 +497,7 @@ export function ConjugationPractice({
     setFeedback(null);
     setIsAnswered(false);
     setIsTimedOut(false);
+    setUserAnswer("");
     setTimeLeft(TIMER_DURATION);
     setCurrentQuestion(null);
     setKey((k) => k + 1);
@@ -513,6 +522,7 @@ export function ConjugationPractice({
     setFeedback(null);
     setIsAnswered(false);
     setIsTimedOut(false);
+    setUserAnswer("");
     setTimeLeft(TIMER_DURATION);
     setCurrentQuestion(null);
     setKey((k) => k + 1);
@@ -542,6 +552,7 @@ export function ConjugationPractice({
     if (!isCorrect) {
       setLastStreakValue(streak);
       setStreak(0);
+      setLastCorrectAnswer(currentQuestion?.correctAnswer ?? null);
       setGameState("lost");
     } else {
       setStreak(newStreak);
@@ -647,21 +658,21 @@ export function ConjugationPractice({
     const isUserChoice = option === userAnswer;
 
     if (isCorrectAnswer) {
-      return "bg-[#1F4BFF] text-white border-[#1F4BFF] hover:bg-[#1637CC] disabled:opacity-100";
+      return "bg-[#22C55E] text-white border-[#22C55E] hover:bg-[#16A34A] disabled:opacity-100";
     }
     if (isUserChoice && !isCorrectAnswer) {
-      return "bg-[#FF6A4D] text-white border-[#FF6A4D] hover:bg-[#D95A3F] disabled:opacity-100";
+      return "bg-[#FF6A4D] text-white border-[#FF6A4D] disabled:opacity-100";
     }
-    return "bg-white text-[#0B1020] border border-gray-200 opacity-50";
+    return "bg-white text-[#0B1020] border border-gray-200 opacity-40";
   };
 
   const getInputClass = () => {
     if (!isAnswered)
       return "bg-[#FAFAF7] border-gray-200 focus-visible:ring-[#1F4BFF] focus-visible:border-[#0B1020]";
     if (feedback === "correct")
-      return "bg-green-100 border-green-500 focus-visible:ring-green-500";
+      return "bg-[#DCFCE7] border-[#22C55E] text-[#15803D] focus-visible:ring-[#22C55E]";
     if (feedback === "incorrect")
-      return "bg-red-100 border-red-500 focus-visible:ring-red-500";
+      return "bg-[#FEE2E2] border-[#FF6A4D] text-[#DC2626] focus-visible:ring-[#FF6A4D]";
     return "bg-[#FAFAF7]";
   };
 
@@ -822,6 +833,31 @@ export function ConjugationPractice({
           >
             Start Streak →
           </button>
+          {userStats && (
+            <div className="flex justify-center gap-3 mt-3">
+              <div
+                className="flex items-center gap-1 text-xs text-gray-500"
+                style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+              >
+                <span>📅</span>
+                <span>{userStats.dailyStreak}d streak</span>
+              </div>
+              <div
+                className="flex items-center gap-1 text-xs text-gray-500"
+                style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+              >
+                <span>🎯</span>
+                <span>{userStats.totalCorrect} correct</span>
+              </div>
+              <div
+                className="flex items-center gap-1 text-xs text-gray-500"
+                style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+              >
+                <span>🔥</span>
+                <span>Best: {gameMode === "classic" ? userStats.classicLongestStreak : userStats.randomLongestStreak}</span>
+              </div>
+            </div>
+          )}
         </div>
       )}
 
@@ -856,6 +892,22 @@ export function ConjugationPractice({
               ? `${lastStreakValue} in a row — not bad.`
               : "You'll get it next time."}
           </p>
+          {lastCorrectAnswer && (
+            <div className="mt-3 text-center">
+              <p
+                className="text-xs text-gray-400 mb-1"
+                style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+              >
+                The answer was
+              </p>
+              <p
+                className="text-lg font-bold"
+                style={{ color: "#22C55E", fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+              >
+                {lastCorrectAnswer}
+              </p>
+            </div>
+          )}
           <button
             onClick={handleTryAgain}
             className="w-full h-14 rounded-xl text-white font-bold text-base transition-all hover:opacity-90 active:scale-[0.98]"

--- a/src/app/components/user-menu.tsx
+++ b/src/app/components/user-menu.tsx
@@ -46,7 +46,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
             onClick={onBackToMenu}
             variant="ghost"
             size="icon"
-            className="text-white hover:bg-white/10"
+            className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
             title="Back to menu"
           >
             <House className="h-5 w-5" />
@@ -57,7 +57,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
             onClick={onOpenStudy}
             variant="ghost"
             size="icon"
-            className="text-white hover:bg-white/10"
+            className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
             title="Study Mode"
           >
             <BookOpen className="h-5 w-5" />
@@ -67,7 +67,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
           onClick={handleChallengeFriend}
           variant="ghost"
           size="icon"
-          className="text-white hover:bg-white/10"
+          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
           title="Challenge a friend"
         >
           <Share2 className="h-5 w-5" />
@@ -77,7 +77,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
             onClick={onShowOnboarding}
             variant="ghost"
             size="icon"
-            className="text-white hover:bg-white/10"
+            className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
             title="How to play"
           >
             <HelpCircle className="h-5 w-5" />
@@ -87,7 +87,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
           onClick={onShowLeaderboard}
           variant="ghost"
           size="icon"
-          className="text-white hover:bg-white/10"
+          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
           title="Leaderboard"
         >
           <Trophy className="h-5 w-5" />
@@ -95,7 +95,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
         <Button
           onClick={signInWithGoogle}
           variant="ghost"
-          className="text-white hover:bg-white/10 gap-2"
+          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors gap-2"
         >
           <LogIn className="h-4 w-4" />
           <span className="hidden sm:inline">Sign in</span>
@@ -111,7 +111,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
           onClick={onBackToMenu}
           variant="ghost"
           size="icon"
-          className="text-white hover:bg-white/10"
+          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
           title="Back to menu"
         >
           <House className="h-5 w-5" />
@@ -122,7 +122,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
           onClick={onOpenStudy}
           variant="ghost"
           size="icon"
-          className="text-white hover:bg-white/10"
+          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
           title="Study Mode"
         >
           <BookOpen className="h-5 w-5" />
@@ -132,7 +132,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
         onClick={handleChallengeFriend}
         variant="ghost"
         size="icon"
-        className="text-white hover:bg-white/10"
+        className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
         title="Challenge a friend"
       >
         <Share2 className="h-5 w-5" />
@@ -142,7 +142,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
           onClick={onShowOnboarding}
           variant="ghost"
           size="icon"
-          className="text-white hover:bg-white/10"
+          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
           title="How to play"
         >
           <HelpCircle className="h-5 w-5" />
@@ -152,7 +152,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
         onClick={onShowLeaderboard}
         variant="ghost"
         size="icon"
-        className="text-white hover:bg-white/10"
+        className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
         title="Leaderboard"
       >
         <Trophy className="h-5 w-5" />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -90,5 +90,7 @@
   body {
     font-family: var(--font-display);
     @apply bg-background text-foreground;
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
     "Master French verb conjugations with interactive flashcards. Practice présent, imparfait, futur, passé composé and more.",
   manifest: "/manifest.json",
   themeColor: "#0B1020",
-  viewport: "width=device-width, initial-scale=1, maximum-scale=1",
+  viewport: "width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover",
 };
 
 export default function RootLayout({
@@ -23,6 +23,9 @@ export default function RootLayout({
     <html lang="en" className="h-full">
       <head>
         <link rel="apple-touch-icon" href="/icons/icon-192.png" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <meta name="mobile-web-app-capable" content="yes" />
       </head>
       <body className={cn("font-body antialiased h-full")}>
         <AuthProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,49 +85,16 @@ export default function Home() {
         />
       </div>
 
-      {/* User stats badges (signed-in only) */}
-      {userStats && (
-        <div className="absolute top-4 left-4 flex gap-2 z-10">
-          {/* Daily streak */}
-          <div
-            title="Daily Streak — consecutive days you've practiced"
-            className="flex items-center gap-1.5 bg-white/10 border border-white/20 rounded-full px-3 py-1 cursor-default"
-          >
-            <span className="text-sm">📅</span>
-            <span
-              className="text-white text-xs font-semibold tabular-nums"
-              style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
-            >
-              {userStats.dailyStreak}d
-            </span>
-          </div>
-          {/* Total correct */}
-          <div
-            title="Total Correct — all-time correct answers"
-            className="flex items-center gap-1.5 bg-white/10 border border-white/20 rounded-full px-3 py-1 cursor-default"
-          >
-            <span className="text-sm">🎯</span>
-            <span
-              className="text-white text-xs font-semibold tabular-nums"
-              style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
-            >
-              {userStats.totalCorrect}
-            </span>
-          </div>
-        </div>
-      )}
-
       {/* Center content — grows to fill space */}
       <div className="flex-1 flex flex-col items-center justify-center w-full">
         <div className="w-full max-w-md">
           <header className="text-center mb-6">
             {/* Brand mark + wordmark */}
-            <div className="flex items-end justify-center gap-3 mb-2">
+            <div className="flex items-center justify-center gap-3 mb-2">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="40 30 220 180"
                 className="h-10 sm:h-12 w-auto flex-shrink-0"
-                style={{ marginBottom: "2px" }}
                 aria-hidden="true"
               >
                 <g transform="translate(40 40)">
@@ -191,6 +158,7 @@ export default function Home() {
             onNextQuestion={() => {}}
             onStatsUpdate={setUserStats}
             onStreakRecord={handleStreakRecord}
+            userStats={userStats}
           />
         </div>
       </div>


### PR DESCRIPTION
Implements all 6 fixes from issue #17:

- Fix 1: Standardize top bar icon button styles, remove top-left stats badges
- Fix 2: PWA fullscreen meta tags, safe area padding, manifest display=fullscreen
- Fix 3: Logo + wordmark optical centering via items-center
- Fix 4: Green #22C55E for correct answers, coral for wrong, loss screen shows correct answer
- Fix 5: Ghost selection bug fixed by resetting userAnswer on try-again and mode switches
- Fix 6: Stats pills in Start overlay when signed in

Closes #17

Generated with [Claude Code](https://claude.ai/code)