### PR TITLE
fix: auth persistence + "Jump back in" CTA for signed-in users

### DIFF
--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -190,7 +190,7 @@ export function ConjugationPractice({
   const inputRef = useRef<HTMLInputElement>(null);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const prepareNextStageRef = useRef<() => void>(() => {});
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
 
   const timerEnabled = !practiceOnly && competitiveMode;
 
@@ -958,6 +958,15 @@ export function ConjugationPractice({
           >
             Start Streak →
           </button>
+          {user && !authLoading && (
+            <button
+              onClick={handleStartStreak}
+              className="w-full rounded-full border py-3 text-sm font-semibold"
+              style={{ borderColor: '#1F4BFF', color: '#1F4BFF' }}
+            >
+              Jump back in →
+            </button>
+          )}
           {userStats && (
             <div className="flex justify-center gap-3 mt-3">
               <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,6 +67,20 @@ export default function Home() {
     setShowStudyMode(true);
   }, []);
 
+  if (loading) {
+    return (
+      <main
+        className="flex min-h-screen w-full items-center justify-center"
+        style={{
+          background:
+            "radial-gradient(ellipse at 0% 0%, rgba(31,75,255,0.15) 0%, transparent 50%), radial-gradient(ellipse at 100% 100%, rgba(255,106,77,0.15) 0%, transparent 50%), #0B1020",
+        }}
+      >
+        <div className="h-10 w-10 border-4 border-dashed rounded-full animate-spin border-[#1F4BFF]" />
+      </main>
+    );
+  }
+
   return (
     <main
       className="flex min-h-screen w-full flex-col items-center p-4 sm:p-6 lg:p-8 pb-6"


### PR DESCRIPTION
Fixes #25

## Changes

- `src/app/page.tsx`: Render a neutral spinner while Firebase Auth resolves, preventing the flash to guest/sign-in UI for returning signed-in users
- `src/app/components/conjugation-practice.tsx`: Add "Jump back in →" CTA on the idle overlay, visible only when `user !== null && !authLoading`

Generated with [Claude Code](https://claude.ai/code)