### PR TITLE
fix: home interrupt screen, top bar two-row layout, MC ghost highlight

### DIFF
--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -52,6 +52,10 @@ type ConjugationPracticeProps = {
   onStreakRecord?: (type: "personal" | "global") => void;
   practiceOnly?: boolean;
   userStats?: UserStats | null;
+  showHomeInterrupt?: boolean;
+  onHomeInterruptDismiss?: () => void;
+  onGoHome?: () => void;
+  onGameStateChange?: (state: GameState) => void;
 };
 
 const TIMER_DURATION = 15;
@@ -151,6 +155,10 @@ export function ConjugationPractice({
   onStreakRecord,
   practiceOnly = false,
   userStats = null,
+  showHomeInterrupt = false,
+  onHomeInterruptDismiss,
+  onGoHome,
+  onGameStateChange,
 }: ConjugationPracticeProps) {
   const [gameState, setGameState] = useState<GameState>(
     practiceOnly ? "playing" : "idle"
@@ -190,7 +198,7 @@ export function ConjugationPractice({
   const inputRef = useRef<HTMLInputElement>(null);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const prepareNextStageRef = useRef<() => void>(() => {});
-  const { user, loading: authLoading } = useAuth();
+  const { user } = useAuth();
 
   const timerEnabled = !practiceOnly && competitiveMode;
 
@@ -294,11 +302,12 @@ export function ConjugationPractice({
   );
 
   const prepareNextStage = useCallback(() => {
+    // Reset answer state BEFORE generating the next question so the
+    // new question always renders with cleared highlights in the same batch.
     setUserAnswer("");
     setFeedback(null);
     setIsAnswered(false);
     setIsTimedOut(false);
-    setKey((prev) => prev + 1);
     onNextQuestion();
 
     // practiceOnly: always multiple-choice, no fill-in drills
@@ -311,6 +320,7 @@ export function ConjugationPractice({
         const pair = `${nextQ.verb}|${nextQ.pronoun}`;
         setCurrentQuestion(getQuestionDetails(nextQ, "multiple-choice"));
         setRecentRandomPairs([...trimmed, pair]);
+        setKey((prev) => prev + 1);
       } else {
         // Classic cycle
         const nextIdx = classicCycleIndex + 1;
@@ -332,6 +342,7 @@ export function ConjugationPractice({
                 "multiple-choice"
               )
             );
+            setKey((prev) => prev + 1);
             return;
           }
         }
@@ -352,6 +363,7 @@ export function ConjugationPractice({
               "multiple-choice"
             )
           );
+          setKey((prev) => prev + 1);
         }
       }
       return;
@@ -380,6 +392,7 @@ export function ConjugationPractice({
           "fill-in-the-blank"
         );
         setCurrentQuestion(detail);
+        setKey((prev) => prev + 1);
       } else {
         const trimmed = recentRandomPairs.slice(-4);
         const nextQ = pickRandomQuestion(trimmed);
@@ -388,6 +401,7 @@ export function ConjugationPractice({
         setMode(nextMode);
         setCurrentQuestion(getQuestionDetails(nextQ, nextMode));
         setRecentRandomPairs([...trimmed, pair]);
+        setKey((prev) => prev + 1);
       }
       return;
     }
@@ -416,6 +430,7 @@ export function ConjugationPractice({
             nextMode
           )
         );
+        setKey((prev) => prev + 1);
         return;
       }
     }
@@ -438,6 +453,7 @@ export function ConjugationPractice({
           nextMode
         )
       );
+      setKey((prev) => prev + 1);
     }
   }, [
     feedback,
@@ -662,6 +678,16 @@ export function ConjugationPractice({
     setClassicVerbTenseQueue([]);
   };
 
+  // Report game state changes to parent
+  useEffect(() => {
+    onGameStateChange?.(gameState);
+  }, [gameState, onGameStateChange]);
+
+  const handleGoHome = () => {
+    handleTryAgain();
+    onGoHome?.();
+  };
+
   const handleAnswer = (answer: string) => {
     if (isAnswered) return;
 
@@ -755,6 +781,9 @@ export function ConjugationPractice({
 
   // Handler for Next in practiceOnly wrong answer
   const handlePracticeOnlyNext = () => {
+    setUserAnswer("");
+    setFeedback(null);
+    setIsAnswered(false);
     setFillInTheBlankQueue([]);
     prepareNextStageRef.current();
   };
@@ -958,15 +987,6 @@ export function ConjugationPractice({
           >
             Start Streak →
           </button>
-          {user && !authLoading && (
-            <button
-              onClick={handleStartStreak}
-              className="w-full rounded-full border py-3 text-sm font-semibold"
-              style={{ borderColor: '#1F4BFF', color: '#1F4BFF' }}
-            >
-              Jump back in →
-            </button>
-          )}
           {userStats && (
             <div className="flex justify-center gap-3 mt-3">
               <div
@@ -1068,8 +1088,61 @@ export function ConjugationPractice({
         </div>
       )}
 
+      {/* HOME INTERRUPT OVERLAY — signed-in users only, during play */}
+      {!practiceOnly && showHomeInterrupt && gameState === "playing" && (
+        <div
+          className="rounded-2xl shadow-xl p-8 text-center space-y-4 animate-in fade-in-0 zoom-in-95"
+          style={{
+            backgroundColor: "#FAFAF7",
+            border: "1px solid rgba(31,75,255,0.12)",
+          }}
+        >
+          <h2
+            className="text-2xl"
+            style={{
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              fontWeight: 800,
+              color: "#0B1020",
+            }}
+          >
+            Taking a break?
+          </h2>
+          <p
+            className="text-sm"
+            style={{
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              color: "rgba(11,16,32,0.6)",
+            }}
+          >
+            Your streak is waiting.
+          </p>
+          <button
+            onClick={onHomeInterruptDismiss}
+            className="w-full h-14 rounded-xl text-white font-bold text-base transition-all hover:opacity-90 active:scale-[0.98]"
+            style={{
+              backgroundColor: "#1F4BFF",
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              fontWeight: 700,
+            }}
+          >
+            Jump Back In →
+          </button>
+          <button
+            onClick={handleGoHome}
+            className="w-full h-12 rounded-xl font-semibold text-base border-2 transition-all hover:bg-[#1F4BFF]/5 active:scale-[0.98]"
+            style={{
+              borderColor: "#1F4BFF",
+              color: "#1F4BFF",
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+            }}
+          >
+            Go Home
+          </button>
+        </div>
+      )}
+
       {/* GAME CARD */}
-      {(practiceOnly || gameState === "playing") && (
+      {(practiceOnly || gameState === "playing") && !showHomeInterrupt && (
         currentQuestion ? (
           <Card
             key={key}

--- a/src/app/components/user-menu.tsx
+++ b/src/app/components/user-menu.tsx
@@ -20,6 +20,7 @@ type UserMenuProps = {
   onShowOnboarding?: () => void;
   onBackToMenu?: () => void;
   onOpenStudy?: () => void;
+  fullWidth?: boolean;
 };
 
 const handleChallengeFriend = () => {
@@ -29,90 +30,28 @@ const handleChallengeFriend = () => {
   window.open(`https://wa.me/?text=${message}`, "_blank");
 };
 
-export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, onOpenStudy }: UserMenuProps) {
+const iconClass = "h-11 w-11 text-white/70 hover:text-white hover:bg-white/10 transition-colors";
+
+export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, onOpenStudy, fullWidth = false }: UserMenuProps) {
   const { user, signInWithGoogle, signOut, isGuest, loading } = useAuth();
 
   if (loading) {
     return (
-      <div className="h-10 w-10 rounded-full bg-white/20 animate-pulse" />
-    );
-  }
-
-  if (isGuest) {
-    return (
-      <div className="flex gap-2">
-        {onBackToMenu && (
-          <Button
-            onClick={onBackToMenu}
-            variant="ghost"
-            size="icon"
-            className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
-            title="Back to menu"
-          >
-            <House className="h-5 w-5" />
-          </Button>
-        )}
-        {onOpenStudy && (
-          <Button
-            onClick={onOpenStudy}
-            variant="ghost"
-            size="icon"
-            className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
-            title="Study Mode"
-          >
-            <BookOpen className="h-5 w-5" />
-          </Button>
-        )}
-        <Button
-          onClick={handleChallengeFriend}
-          variant="ghost"
-          size="icon"
-          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
-          title="Challenge a friend"
-        >
-          <Share2 className="h-5 w-5" />
-        </Button>
-        {onShowOnboarding && (
-          <Button
-            onClick={onShowOnboarding}
-            variant="ghost"
-            size="icon"
-            className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
-            title="How to play"
-          >
-            <HelpCircle className="h-5 w-5" />
-          </Button>
-        )}
-        <Button
-          onClick={onShowLeaderboard}
-          variant="ghost"
-          size="icon"
-          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
-          title="Leaderboard"
-        >
-          <Trophy className="h-5 w-5" />
-        </Button>
-        <Button
-          onClick={signInWithGoogle}
-          variant="ghost"
-          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors gap-2"
-        >
-          <LogIn className="h-4 w-4" />
-          <span className="hidden sm:inline">Sign in</span>
-        </Button>
+      <div className={fullWidth ? "flex items-center justify-between w-full" : "flex gap-2"}>
+        <div className="h-11 w-11 rounded-full bg-white/20 animate-pulse" />
       </div>
     );
   }
 
-  return (
-    <div className="flex gap-2">
+  const navIcons = (
+    <div className="flex items-center gap-1">
       {onBackToMenu && (
         <Button
           onClick={onBackToMenu}
           variant="ghost"
           size="icon"
-          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
-          title="Back to menu"
+          className={iconClass}
+          title="Home"
         >
           <House className="h-5 w-5" />
         </Button>
@@ -122,7 +61,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
           onClick={onOpenStudy}
           variant="ghost"
           size="icon"
-          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+          className={iconClass}
           title="Study Mode"
         >
           <BookOpen className="h-5 w-5" />
@@ -132,7 +71,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
         onClick={handleChallengeFriend}
         variant="ghost"
         size="icon"
-        className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+        className={iconClass}
         title="Challenge a friend"
       >
         <Share2 className="h-5 w-5" />
@@ -142,7 +81,7 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
           onClick={onShowOnboarding}
           variant="ghost"
           size="icon"
-          className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+          className={iconClass}
           title="How to play"
         >
           <HelpCircle className="h-5 w-5" />
@@ -152,55 +91,135 @@ export function UserMenu({ onShowLeaderboard, onShowOnboarding, onBackToMenu, on
         onClick={onShowLeaderboard}
         variant="ghost"
         size="icon"
-        className="text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+        className={iconClass}
         title="Leaderboard"
       >
         <Trophy className="h-5 w-5" />
       </Button>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            className="relative h-10 w-10 rounded-full p-0 hover:bg-white/10"
-          >
-            <Avatar className="h-9 w-9 border-2 border-white/30">
-              <AvatarImage
-                src={user?.photoURL ?? undefined}
-                alt={user?.displayName ?? "User"}
-              />
-              <AvatarFallback className="bg-white/20 text-white">
-                <User className="h-4 w-4" />
-              </AvatarFallback>
-            </Avatar>
+    </div>
+  );
+
+  if (isGuest) {
+    const authButton = (
+      <Button
+        onClick={signInWithGoogle}
+        variant="ghost"
+        className="text-white/70 hover:text-white hover:bg-white/10 transition-colors gap-2"
+      >
+        <LogIn className="h-4 w-4" />
+        <span className="hidden sm:inline">Sign in</span>
+      </Button>
+    );
+
+    return fullWidth ? (
+      <div className="flex items-center justify-between w-full">
+        {navIcons}
+        {authButton}
+      </div>
+    ) : (
+      <div className="flex gap-2 items-center">
+        {onBackToMenu && (
+          <Button onClick={onBackToMenu} variant="ghost" size="icon" className={iconClass} title="Home">
+            <House className="h-5 w-5" />
           </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-56">
-          <DropdownMenuLabel>
-            <div className="flex flex-col space-y-1">
-              <p className="text-sm font-medium">{user?.displayName}</p>
-              <p className="text-xs text-muted-foreground truncate">
-                {user?.email}
-              </p>
-            </div>
-          </DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={onShowLeaderboard}>
-            <Trophy className="mr-2 h-4 w-4" />
-            Leaderboard
+        )}
+        {onOpenStudy && (
+          <Button onClick={onOpenStudy} variant="ghost" size="icon" className={iconClass} title="Study Mode">
+            <BookOpen className="h-5 w-5" />
+          </Button>
+        )}
+        <Button onClick={handleChallengeFriend} variant="ghost" size="icon" className={iconClass} title="Challenge a friend">
+          <Share2 className="h-5 w-5" />
+        </Button>
+        {onShowOnboarding && (
+          <Button onClick={onShowOnboarding} variant="ghost" size="icon" className={iconClass} title="How to play">
+            <HelpCircle className="h-5 w-5" />
+          </Button>
+        )}
+        <Button onClick={onShowLeaderboard} variant="ghost" size="icon" className={iconClass} title="Leaderboard">
+          <Trophy className="h-5 w-5" />
+        </Button>
+        {authButton}
+      </div>
+    );
+  }
+
+  const avatarMenu = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          className="relative h-11 w-11 rounded-full p-0 hover:bg-white/10"
+        >
+          <Avatar className="h-9 w-9 border-2 border-white/30">
+            <AvatarImage
+              src={user?.photoURL ?? undefined}
+              alt={user?.displayName ?? "User"}
+            />
+            <AvatarFallback className="bg-white/20 text-white">
+              <User className="h-4 w-4" />
+            </AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>
+          <div className="flex flex-col space-y-1">
+            <p className="text-sm font-medium">{user?.displayName}</p>
+            <p className="text-xs text-muted-foreground truncate">
+              {user?.email}
+            </p>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={onShowLeaderboard}>
+          <Trophy className="mr-2 h-4 w-4" />
+          Leaderboard
+        </DropdownMenuItem>
+        {onShowOnboarding && (
+          <DropdownMenuItem onClick={onShowOnboarding}>
+            <HelpCircle className="mr-2 h-4 w-4" />
+            How to Play
           </DropdownMenuItem>
-          {onShowOnboarding && (
-            <DropdownMenuItem onClick={onShowOnboarding}>
-              <HelpCircle className="mr-2 h-4 w-4" />
-              How to Play
-            </DropdownMenuItem>
-          )}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={signOut}>
-            <LogOut className="mr-2 h-4 w-4" />
-            Sign out
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={signOut}>
+          <LogOut className="mr-2 h-4 w-4" />
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  return fullWidth ? (
+    <div className="flex items-center justify-between w-full">
+      {navIcons}
+      {avatarMenu}
+    </div>
+  ) : (
+    <div className="flex gap-2 items-center">
+      {onBackToMenu && (
+        <Button onClick={onBackToMenu} variant="ghost" size="icon" className={iconClass} title="Home">
+          <House className="h-5 w-5" />
+        </Button>
+      )}
+      {onOpenStudy && (
+        <Button onClick={onOpenStudy} variant="ghost" size="icon" className={iconClass} title="Study Mode">
+          <BookOpen className="h-5 w-5" />
+        </Button>
+      )}
+      <Button onClick={handleChallengeFriend} variant="ghost" size="icon" className={iconClass} title="Challenge a friend">
+        <Share2 className="h-5 w-5" />
+      </Button>
+      {onShowOnboarding && (
+        <Button onClick={onShowOnboarding} variant="ghost" size="icon" className={iconClass} title="How to play">
+          <HelpCircle className="h-5 w-5" />
+        </Button>
+      )}
+      <Button onClick={onShowLeaderboard} variant="ghost" size="icon" className={iconClass} title="Leaderboard">
+        <Trophy className="h-5 w-5" />
+      </Button>
+      {avatarMenu}
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,8 @@ export default function Home() {
     "personal" | "global" | null
   >(null);
   const [userStats, setUserStats] = useState<UserStats | null>(null);
+  const [showHomeInterrupt, setShowHomeInterrupt] = useState(false);
+  const [currentGameState, setCurrentGameState] = useState<"idle" | "playing" | "lost">("idle");
   const { user, loading } = useAuth();
 
   // Manage onboarding visibility and user stats based on auth state
@@ -67,6 +69,20 @@ export default function Home() {
     setShowStudyMode(true);
   }, []);
 
+  // Auto-dismiss interrupt if game is no longer playing
+  useEffect(() => {
+    if (currentGameState !== "playing") {
+      setShowHomeInterrupt(false);
+    }
+  }, [currentGameState]);
+
+  const handleHomeClick = useCallback(() => {
+    if (user && currentGameState === "playing") {
+      setShowHomeInterrupt(true);
+    }
+    // Guest or idle: no-op (player is already at the idle screen)
+  }, [user, currentGameState]);
+
   if (loading) {
     return (
       <main
@@ -89,90 +105,96 @@ export default function Home() {
           "radial-gradient(ellipse at 0% 0%, rgba(31,75,255,0.15) 0%, transparent 50%), radial-gradient(ellipse at 100% 100%, rgba(255,106,77,0.15) 0%, transparent 50%), #0B1020",
       }}
     >
-      {/* Top bar */}
-      <div className="absolute top-4 right-4 z-10">
-        <UserMenu
-          onShowLeaderboard={() => setShowLeaderboard(true)}
-          onShowOnboarding={() => setShowOnboarding(true)}
-          onBackToMenu={() => setShowOnboarding(true)}
-          onOpenStudy={handleOpenStudy}
-        />
+      {/* Two-row header: Row 1 = logo/wordmark/tagline, Row 2 = nav icons */}
+      <div className="w-full max-w-md">
+        {/* Row 1: Brand mark + wordmark + tagline */}
+        <header className="text-center mb-3">
+          <div className="flex items-center justify-center gap-3 mb-2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="40 30 220 180"
+              className="h-10 sm:h-12 w-auto flex-shrink-0"
+              aria-hidden="true"
+            >
+              <g transform="translate(40 40)">
+                <defs>
+                  <linearGradient
+                    id="vf-mark-header"
+                    x1="25"
+                    x2="185"
+                    y1="0"
+                    y2="0"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop offset="50%" stopColor="#FF6A4D" />
+                    <stop offset="50%" stopColor="#1F4BFF" />
+                  </linearGradient>
+                </defs>
+                <path
+                  d="M40 50 L105 160 L170 50"
+                  fill="none"
+                  stroke="#FFFFFF"
+                  strokeWidth="22"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M25 100 Q70 70 105 100 T185 100"
+                  fill="none"
+                  stroke="url(#vf-mark-header)"
+                  strokeWidth="14"
+                  strokeLinecap="round"
+                />
+              </g>
+            </svg>
+            <span
+              className="text-4xl sm:text-5xl"
+              style={{
+                fontFamily: "'Plus Jakarta Sans', sans-serif",
+                letterSpacing: "-2px",
+                lineHeight: 1,
+              }}
+            >
+              <span className="font-bold text-white">verbum</span>
+              <span style={{ fontWeight: 800, color: "#FF6A4D" }}>flow</span>
+            </span>
+          </div>
+          <p
+            className="text-xs text-white uppercase"
+            style={{
+              fontFamily: "'JetBrains Mono', monospace",
+              letterSpacing: "4px",
+              opacity: 0.6,
+            }}
+          >
+            LEARN AND COMPETE
+          </p>
+        </header>
+
+        {/* Row 2: Nav icons (left) + avatar (right) */}
+        <div className="mb-4">
+          <UserMenu
+            fullWidth
+            onShowLeaderboard={() => setShowLeaderboard(true)}
+            onShowOnboarding={() => setShowOnboarding(true)}
+            onBackToMenu={handleHomeClick}
+            onOpenStudy={handleOpenStudy}
+          />
+        </div>
       </div>
 
       {/* Center content — grows to fill space */}
       <div className="flex-1 flex flex-col items-center justify-center w-full">
         <div className="w-full max-w-md">
-          <header className="text-center mb-6">
-            {/* Brand mark + wordmark */}
-            <div className="flex items-center justify-center gap-3 mb-2">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="40 30 220 180"
-                className="h-10 sm:h-12 w-auto flex-shrink-0"
-                aria-hidden="true"
-              >
-                <g transform="translate(40 40)">
-                  <defs>
-                    <linearGradient
-                      id="vf-mark-header"
-                      x1="25"
-                      x2="185"
-                      y1="0"
-                      y2="0"
-                      gradientUnits="userSpaceOnUse"
-                    >
-                      <stop offset="50%" stopColor="#FF6A4D" />
-                      <stop offset="50%" stopColor="#1F4BFF" />
-                    </linearGradient>
-                  </defs>
-                  <path
-                    d="M40 50 L105 160 L170 50"
-                    fill="none"
-                    stroke="#FFFFFF"
-                    strokeWidth="22"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M25 100 Q70 70 105 100 T185 100"
-                    fill="none"
-                    stroke="url(#vf-mark-header)"
-                    strokeWidth="14"
-                    strokeLinecap="round"
-                  />
-                </g>
-              </svg>
-              {/* Wordmark */}
-              <span
-                className="text-4xl sm:text-5xl"
-                style={{
-                  fontFamily: "'Plus Jakarta Sans', sans-serif",
-                  letterSpacing: "-2px",
-                  lineHeight: 1,
-                }}
-              >
-                <span className="font-bold text-white">verbum</span>
-                <span style={{ fontWeight: 800, color: "#FF6A4D" }}>flow</span>
-              </span>
-            </div>
-            {/* Tagline */}
-            <p
-              className="text-xs text-white uppercase"
-              style={{
-                fontFamily: "'JetBrains Mono', monospace",
-                letterSpacing: "4px",
-                opacity: 0.6,
-              }}
-            >
-              LEARN AND COMPETE
-            </p>
-          </header>
-
           <ConjugationPractice
             onNextQuestion={() => {}}
             onStatsUpdate={setUserStats}
             onStreakRecord={handleStreakRecord}
             userStats={userStats}
+            showHomeInterrupt={showHomeInterrupt}
+            onHomeInterruptDismiss={() => setShowHomeInterrupt(false)}
+            onGoHome={() => setShowHomeInterrupt(false)}
+            onGameStateChange={setCurrentGameState}
           />
         </div>
       </div>


### PR DESCRIPTION
Fixes #27

## Summary

- Removed "Jump Back In" from idle overlay; signed-in users clicking Home while playing now see an interrupt screen with options to resume or go home
- Restructured top bar from absolute-positioned overlay to a proper two-row header (logo row + nav row) at all viewport widths
- Fixed MC answer ghost highlight: answer state now cleared before setCurrentQuestion and setKey in every code path

Generated with [Claude Code](https://claude.ai/code)