### PR TITLE
fix: top bar layout — avatar fixed top-right, logo centered with clearance, nav icons centered below

### DIFF
--- a/src/app/components/user-menu.tsx
+++ b/src/app/components/user-menu.tsx
@@ -56,18 +56,18 @@ export function UserMenu({
   if (loading) {
     return (
       <>
-        <div className="flex justify-center gap-6">
+        <div className="flex justify-center gap-8">
           {[...Array(5)].map((_, i) => (
             <div key={i} className="h-11 w-11 rounded-full bg-white/10 animate-pulse" />
           ))}
         </div>
-        <div className="fixed top-4 right-4 z-50 h-9 w-9 rounded-full bg-white/20 animate-pulse" />
+        <div className="fixed top-3 right-3 z-50 h-10 w-10 rounded-full bg-white/20 animate-pulse" />
       </>
     );
   }
 
   const navRow = (
-    <div className="flex justify-center gap-6">
+    <div className="flex justify-center gap-8">
       {navItems.map(({ icon: Icon, label, onClick, screen }) => {
         if (!onClick) return null;
         const isActive = screen !== undefined && activeScreen === screen;
@@ -90,7 +90,7 @@ export function UserMenu({
   const avatarEl = isGuest ? (
     <button
       onClick={signInWithGoogle}
-      className="fixed top-4 right-4 z-50 p-2 rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none"
+      className="fixed top-3 right-3 z-50 h-10 w-10 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none"
       title="Sign in with Google"
       aria-label="Sign in with Google"
     >
@@ -100,7 +100,7 @@ export function UserMenu({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
-          className="fixed top-4 right-4 z-50 h-9 w-9 rounded-full border-2 border-white/30 overflow-hidden hover:border-white/60 transition-colors focus:outline-none"
+          className="fixed top-3 right-3 z-50 h-10 w-10 rounded-full border-2 border-white/30 overflow-hidden hover:border-white/60 transition-colors focus:outline-none"
           title={user?.displayName ?? "Account"}
           aria-label="Account menu"
         >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -116,7 +116,7 @@ export default function Home() {
       {/* Two-row header: Row 1 = logo/wordmark/tagline, Row 2 = nav icons */}
       <div className="w-full max-w-md">
         {/* Row 1: Brand mark + wordmark + tagline */}
-        <header className="text-center mb-3">
+        <header className="text-center mb-3 pt-14">
           <div className="flex items-center justify-center gap-3 mb-2">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -180,7 +180,7 @@ export default function Home() {
         </header>
 
         {/* Row 2: Centered nav icons (avatar is fixed top-right) */}
-        <div className="mb-6">
+        <div className="mb-2">
           <UserMenu
             onShowLeaderboard={() => setShowLeaderboard(true)}
             onShowOnboarding={() => setShowOnboarding(true)}


### PR DESCRIPTION
Fixes #35

## Changes

- Avatar and sign-in button: `top-3 right-3` (12px) and `h-10 w-10` (40px circle) per spec
- Header: `pt-14` so logo starts ~72px from viewport top, clearing 52px avatar bottom
- Nav icons row: `gap-6` → `gap-8` per spec
- Nav wrapper: `mb-6` → `mb-2` for tighter spacing below nav row
- Loading skeleton updated to match new positions/sizes

Generated with [Claude Code](https://claude.ai/code)