### PR TITLE
Fix TypeScript errors, duel scoring types, and Next.js metadata warnings

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 // src/app/layout.tsx
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
 import { cn } from "@/lib/utils";
@@ -10,8 +10,14 @@ export const metadata: Metadata = {
   description:
     "Master French verb conjugations with interactive flashcards. Practice présent, imparfait, futur, passé composé and more.",
   manifest: "/manifest.json",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  viewportFit: "cover",
   themeColor: "#0B1020",
-  viewport: "width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover",
 };
 
 export default function RootLayout({

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -1,5 +1,7 @@
 // src/lib/firestore.ts
 import {
+  type DocumentData,
+  type UpdateData,
   doc,
   getDoc,
   setDoc,
@@ -149,7 +151,7 @@ export async function recordAnswer(
 
   const longestDailyStreak = Math.max(data.longestDailyStreak ?? 0, dailyStreak);
 
-  const updates: Record<string, unknown> = {
+  const updates: UpdateData<DocumentData> = {
     totalCorrect: (data.totalCorrect ?? 0) + (isCorrect ? 1 : 0),
     totalAnswered: (data.totalAnswered ?? 0) + 1,
     lastPracticeDate: today,
@@ -309,7 +311,7 @@ export async function submitDuelScore(
 
     const data = duelSnap.data();
     const isChallenger = data.challengerUid === uid;
-    const updates: Record<string, unknown> = {
+    const updates: UpdateData<DocumentData> = {
       [isChallenger ? "challengerScore" : "challengedScore"]: score,
     };
 
@@ -320,16 +322,20 @@ export async function submitDuelScore(
     let winnerId: string | null = data.winnerId;
 
     if (challengerScore !== null && challengedScore !== null) {
-      winnerId =
+      const resolvedWinnerId: string =
         challengerScore >= challengedScore ? data.challengerUid : data.challengedUid;
-      const loserId = winnerId === data.challengerUid ? data.challengedUid : data.challengerUid;
+      winnerId = resolvedWinnerId;
+      const loserId =
+        resolvedWinnerId === data.challengerUid
+          ? data.challengedUid
+          : data.challengerUid;
 
       updates.status = "completed";
-      updates.winnerId = winnerId;
+      updates.winnerId = resolvedWinnerId;
       updates.completedAt = serverTimestamp();
       resultStatus = "completed";
 
-      transaction.update(doc(db, "users", winnerId), { duelsWon: increment(1) });
+      transaction.update(doc(db, "users", resolvedWinnerId), { duelsWon: increment(1) });
       transaction.update(doc(db, "users", loserId), { duelsLost: increment(1) });
     }
 

--- a/src/lib/verbs.ts
+++ b/src/lib/verbs.ts
@@ -677,7 +677,7 @@ export const verbData: VerbData = {
     }
   };
 
-  const rules = {
+  const rules: Record<string, Record<string, string>> = {
     "Présent": {
         "er": "For regular -er verbs, drop the -er and add endings: -e, -es, -e, -ons, -ez, -ent.",
         "ir": "For regular -ir verbs, drop the -ir and add endings: -is, -is, -it, -issons, -issez, -issent.",
@@ -744,7 +744,7 @@ export const verbData: VerbData = {
     }
   };
   
-  const tips = {
+  const tips: Record<string, Record<string, string>> = {
     "Présent": {
         "er": "Think 'parler': je parle, tu parles, il parle, nous parlons, vous parlez, ils parlent.",
         "ir": "Think 'finir': je finis, tu finis, il finit, nous finissons, vous finissez, ils finissent.",
@@ -812,16 +812,15 @@ export const verbData: VerbData = {
     }
     
     // Check for fully irregular verbs that have their own rules
-    const irregularVerbs = ["être", "avoir", "aller", "faire", "pouvoir", "vouloir", "savoir", "dire", "mettre", "prendre", "voir", "devoir", "venir", "croire", "boire", "recevoir", "dormir", "courir", "sentir", "servir"];
     if (rules[tense]?.[verb]) {
       specialCase = verb;
-    } else if (irregularVerbs.includes(verb) && rules[tense]?.[verb]) {
-       specialCase = verb;
     }
 
 
-    let rule = rules[tense]?.[specialCase!] || rules[tense]?.[verbGroup] || rules[tense]?.default || null;
-    let tip = tips[tense]?.[specialCase!] || tips[tense]?.[verbGroup] || tips[tense]?.default || null;
+    const specialCaseRule = specialCase ? rules[tense]?.[specialCase] : null;
+    const specialCaseTip = specialCase ? tips[tense]?.[specialCase] : null;
+    let rule = specialCaseRule || rules[tense]?.[verbGroup] || rules[tense]?.default || null;
+    let tip = specialCaseTip || tips[tense]?.[verbGroup] || tips[tense]?.default || null;
 
     if (tense === "Futur simple" || tense === "Conditionnel Présent") {
         const irregularStems = ["aller", "avoir", "être", "faire", "voir", "pouvoir", "vouloir", "savoir", "devoir", "venir", "envoyer", "recevoir", "courir", "mourir"];


### PR DESCRIPTION
### Motivation
- TypeScript type errors in Firestore and verbs utilities were blocking `npm run typecheck` and increasing the chance of runtime bugs when writing updates or indexing dictionaries.
- Duel scoring code used nullable/wider-typed values when updating user docs which could cause invalid `doc()` calls inside transactions.
- Unsafe non-null indexing in `getRule` risked type errors and brittle lookups for rule/tip text.
- Next.js build reported metadata/viewport warnings that affect PWA metadata handling and should be aligned with Next 15 conventions.

### Description
- Replace loose `Record<string, unknown>` update payloads with Firestore-native `UpdateData<DocumentData>` for safer `updateDoc` usage in `src/lib/firestore.ts`.
- Ensure duel winner resolution is a concrete `string` before calling `doc(db, "users", ...)` and use a `resolvedWinnerId` to update winner/loser counters inside the transaction in `src/lib/firestore.ts`.
- Add explicit indexable types for `rules` and `tips` (`Record<string, Record<string,string>>`) and avoid unsafe non-null indexing by computing `specialCase` then selecting `specialCaseRule`/`specialCaseTip` before falling back in `src/lib/verbs.ts`.
- Move `themeColor` and other viewport-related config out of the `metadata` object into the exported `viewport` (`src/app/layout.tsx`) to satisfy Next.js 15 metadata requirements.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully.
- Ran `npm run build` (`next build`) and the production build completed successfully (static pages generated and exports succeeded).
- Attempted `npm run lint` but the interactive Next.js ESLint setup prompt prevented a non-interactive run, so linting was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfcf184f08329a69cc57b668ec2d0)