### PR TITLE
feat: Animated splash screen + entry screen (#41)

### DIFF
--- a/src/app/components/entry-screen.tsx
+++ b/src/app/components/entry-screen.tsx
@@ -1,0 +1,231 @@
+// src/app/components/entry-screen.tsx
+"use client";
+
+import React from "react";
+import { LogIn, ArrowRight } from "lucide-react";
+import { useAuth } from "@/contexts/auth-context";
+import { Button } from "@/components/ui/button";
+
+const HOW_TO_PLAY = [
+  {
+    icon: "🎮",
+    title: "Classic Mode",
+    desc: "Master one verb at a time. Answer all its pronouns to keep your streak alive.",
+  },
+  {
+    icon: "🎲",
+    title: "Random Mode",
+    desc: "Every question is a wildcard. Harder, faster, more competitive.",
+  },
+  {
+    icon: "🔥",
+    title: "Streak",
+    desc: "Answer correctly, keep going. One wrong answer (or time's up) resets to zero.",
+  },
+  {
+    icon: "⏱",
+    title: "10 seconds",
+    desc: "You have 10 seconds per question. The bar turns red when time is short.",
+  },
+  {
+    icon: "📅",
+    title: "Daily Streak",
+    desc: "Come back every day to build your daily streak. Consistency wins.",
+  },
+];
+
+type EntryScreenProps = {
+  onComplete: () => void;
+};
+
+export function EntryScreen({ onComplete }: EntryScreenProps) {
+  const { signInWithGoogle } = useAuth();
+
+  const handleSignIn = async () => {
+    try {
+      await signInWithGoogle();
+      // Auth state change in page.tsx will unmount this screen automatically
+    } catch {
+      // Ignore errors (user may cancel popup)
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 overflow-y-auto"
+      style={{
+        background:
+          "radial-gradient(ellipse at 0% 0%, rgba(31,75,255,0.15) 0%, transparent 50%), radial-gradient(ellipse at 100% 100%, rgba(255,106,77,0.15) 0%, transparent 50%), #0B1020",
+        animation: "entryFadeIn 0.4s ease-out forwards",
+        willChange: "opacity",
+      }}
+    >
+      <div className="w-full max-w-sm mx-auto px-4 py-8 flex flex-col items-center gap-6">
+        {/* LogoMark + wordmark */}
+        <div className="flex items-center justify-center gap-3 mt-4">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="40 30 220 180"
+            style={{ height: "44px", width: "auto" }}
+            aria-hidden="true"
+          >
+            <g transform="translate(40 40)">
+              <defs>
+                <linearGradient
+                  id="vf-entry-tilde"
+                  x1="25"
+                  x2="185"
+                  y1="0"
+                  y2="0"
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop offset="50%" stopColor="#FF6A4D" />
+                  <stop offset="50%" stopColor="#1F4BFF" />
+                </linearGradient>
+              </defs>
+              <path
+                d="M40 50 L105 160 L170 50"
+                fill="none"
+                stroke="#FFFFFF"
+                strokeWidth="22"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M25 100 Q70 70 105 100 T185 100"
+                fill="none"
+                stroke="url(#vf-entry-tilde)"
+                strokeWidth="14"
+                strokeLinecap="round"
+              />
+            </g>
+          </svg>
+          <span
+            style={{
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              fontSize: "32px",
+              letterSpacing: "-2px",
+              lineHeight: 1,
+            }}
+          >
+            <span style={{ fontWeight: 700, color: "#FFFFFF" }}>verbum</span>
+            <span style={{ fontWeight: 800, color: "#FF6A4D" }}>flow</span>
+          </span>
+        </div>
+
+        {/* Tagline */}
+        <p
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: "11px",
+            letterSpacing: "4px",
+            textTransform: "uppercase",
+            color: "#FFFFFF",
+            opacity: 0.5,
+          }}
+        >
+          LEARN AND COMPETE
+        </p>
+
+        <div className="w-full h-px bg-white/10" />
+
+        {/* Sign in section */}
+        <div className="w-full space-y-3">
+          <Button
+            onClick={handleSignIn}
+            className="w-full rounded-full gap-2 font-semibold text-white"
+            style={{
+              backgroundColor: "#1F4BFF",
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+            }}
+          >
+            <LogIn className="h-4 w-4" />
+            Sign in with Google
+          </Button>
+          <p
+            className="text-center text-xs"
+            style={{
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              color: "rgba(255,255,255,0.5)",
+            }}
+          >
+            Save your streaks, climb the leaderboard, duel friends.
+          </p>
+        </div>
+
+        <div className="w-full h-px bg-white/10" />
+
+        {/* Guest section */}
+        <div className="w-full space-y-3">
+          <Button
+            onClick={onComplete}
+            variant="outline"
+            className="w-full rounded-full gap-2 bg-transparent hover:bg-white/5"
+            style={{
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              borderColor: "rgba(255,255,255,0.5)",
+              color: "rgba(255,255,255,0.5)",
+            }}
+          >
+            Continue as Guest
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+          <p
+            className="text-center text-xs"
+            style={{
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              color: "rgba(255,255,255,0.45)",
+            }}
+          >
+            Guests can&apos;t duel, add friends, or save progress.
+          </p>
+        </div>
+
+        <div className="w-full h-px bg-white/10" />
+
+        {/* How to Play card */}
+        <div
+          className="w-full rounded-2xl p-6 space-y-4"
+          style={{
+            backgroundColor: "#FAFAF7",
+            border: "1px solid rgba(31,75,255,0.12)",
+          }}
+        >
+          <h3
+            className="text-base font-bold text-center"
+            style={{
+              color: "#0B1020",
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+            }}
+          >
+            How to Play
+          </h3>
+          <div className="space-y-3">
+            {HOW_TO_PLAY.map((item) => (
+              <div key={item.title} className="flex gap-3 items-start">
+                <span className="text-xl flex-shrink-0 mt-0.5">{item.icon}</span>
+                <div>
+                  <p
+                    className="text-sm font-semibold"
+                    style={{
+                      color: "#0B1020",
+                      fontFamily: "'Plus Jakarta Sans', sans-serif",
+                    }}
+                  >
+                    {item.title}
+                  </p>
+                  <p
+                    className="text-xs text-gray-500 mt-0.5"
+                    style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+                  >
+                    {item.desc}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/splash-screen.tsx
+++ b/src/app/components/splash-screen.tsx
@@ -1,0 +1,127 @@
+// src/app/components/splash-screen.tsx
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { EntryScreen } from "./entry-screen";
+
+type SplashScreenProps = {
+  onComplete: () => void;
+};
+
+export function SplashScreen({ onComplete }: SplashScreenProps) {
+  const [showEntry, setShowEntry] = useState(false);
+
+  useEffect(() => {
+    // Switch to entry screen when splash fade-out ends (3.6s delay + 0.8s duration)
+    const timer = setTimeout(() => {
+      setShowEntry(true);
+    }, 4400);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (showEntry) {
+    return <EntryScreen onComplete={onComplete} />;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-6"
+      style={{
+        background:
+          "radial-gradient(ellipse at 0% 0%, rgba(31,75,255,0.15) 0%, transparent 50%), radial-gradient(ellipse at 100% 100%, rgba(255,106,77,0.15) 0%, transparent 50%), #0B1020",
+        animation: "splashFadeOut 0.8s ease-in-out 3.6s both",
+        willChange: "opacity",
+      }}
+    >
+      {/* Logomark with V trace + tilde trace animations */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="40 30 220 180"
+        style={{ height: "96px", width: "auto" }}
+        aria-hidden="true"
+      >
+        <g transform="translate(40 40)">
+          <defs>
+            <linearGradient
+              id="vf-splash-tilde"
+              x1="25"
+              x2="185"
+              y1="0"
+              y2="0"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset="50%" stopColor="#FF6A4D" />
+              <stop offset="50%" stopColor="#1F4BFF" />
+            </linearGradient>
+          </defs>
+
+          {/* V path — traces from 0s to 1.2s */}
+          <path
+            d="M40 50 L105 160 L170 50"
+            fill="none"
+            stroke="#FFFFFF"
+            strokeWidth="22"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{
+              strokeDasharray: 300,
+              strokeDashoffset: 300,
+              animation: "traceStroke 1.2s ease-in-out 0s both",
+              willChange: "stroke-dashoffset",
+            }}
+          />
+
+          {/* Tilde path — traces from 1.0s to 2.0s */}
+          <path
+            d="M25 100 Q70 70 105 100 T185 100"
+            fill="none"
+            stroke="url(#vf-splash-tilde)"
+            strokeWidth="14"
+            strokeLinecap="round"
+            style={{
+              strokeDasharray: 300,
+              strokeDashoffset: 300,
+              animation: "traceStroke 1.0s ease-in-out 1.0s both",
+              willChange: "stroke-dashoffset",
+            }}
+          />
+        </g>
+      </svg>
+
+      {/* Wordmark — fades + slides up from 1.8s to 2.6s */}
+      <div
+        style={{
+          animation: "wordmarkReveal 0.8s cubic-bezier(0.16, 1, 0.3, 1) 1.8s both",
+          willChange: "opacity, transform",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "'Plus Jakarta Sans', sans-serif",
+            fontSize: "clamp(36px, 10vw, 56px)",
+            letterSpacing: "-2px",
+            lineHeight: 1,
+          }}
+        >
+          <span style={{ fontWeight: 700, color: "#FFFFFF" }}>verbum</span>
+          <span style={{ fontWeight: 800, color: "#FF6A4D" }}>flow</span>
+        </span>
+      </div>
+
+      {/* Tagline — fades in from 2.6s to 3.4s */}
+      <p
+        style={{
+          fontFamily: "'JetBrains Mono', monospace",
+          fontSize: "11px",
+          letterSpacing: "4px",
+          textTransform: "uppercase",
+          color: "#FFFFFF",
+          animation: "taglineReveal 0.8s ease-out 2.6s both",
+          willChange: "opacity",
+        }}
+      >
+        LEARN AND COMPETE
+      </p>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -94,3 +94,34 @@
     padding-bottom: env(safe-area-inset-bottom);
   }
 }
+
+@keyframes traceStroke {
+  from { stroke-dashoffset: 300; }
+  to   { stroke-dashoffset: 0; }
+}
+
+@keyframes wordmarkReveal {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes taglineReveal {
+  from { opacity: 0; }
+  to   { opacity: 0.5; }
+}
+
+@keyframes splashFadeOut {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+@keyframes entryFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,12 +9,14 @@ import { Felicitations } from "@/app/components/felicitations";
 import { StudyMode } from "@/app/components/study-mode";
 import { UsernameSetup } from "@/app/components/username-setup";
 import { FriendsPanel } from "@/app/components/friends-panel";
+import { SplashScreen } from "@/app/components/splash-screen";
 import { useAuth } from "@/contexts/auth-context";
 import { useState, useEffect, useCallback } from "react";
 import { initializeUserStats, type UserStats } from "@/lib/firestore";
 import { Heart } from "lucide-react";
 
 export default function Home() {
+  const [splashDone, setSplashDone] = useState(false);
   const [showLeaderboard, setShowLeaderboard] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showStudyMode, setShowStudyMode] = useState(false);
@@ -48,16 +50,9 @@ export default function Home() {
         }
       });
     } else {
-      // Guest: show onboarding every session (no localStorage flag)
+      // Guest: splash → entry screen handles the initial prompt
       setUserStats(null);
       setNeedsUsername(false);
-      const onboarded =
-        typeof window !== "undefined"
-          ? localStorage.getItem("vf_onboarded")
-          : null;
-      if (!onboarded) {
-        setShowOnboarding(true);
-      }
     }
   }, [user, loading]);
 
@@ -117,6 +112,11 @@ export default function Home() {
         <div className="h-10 w-10 border-4 border-dashed rounded-full animate-spin border-[#1F4BFF]" />
       </main>
     );
+  }
+
+  // Guest users (not signed in) always go through splash → entry screen on each cold load
+  if (!splashDone && !user) {
+    return <SplashScreen onComplete={() => setSplashDone(true)} />;
   }
 
   return (


### PR DESCRIPTION
Implements the animated splash screen and polished sign-in/guest entry screen as described in issue #41.

## Changes

- New `SplashScreen` component with CSS-only stroke trace animations
- New `EntryScreen` component (Google sign-in, guest, How to Play)
- Updated `page.tsx` to show splash for guests, skip for signed-in users
- Added @keyframes to globals.css

Closes #41

Generated with [Claude Code](https://claude.ai/code)