### PR TITLE
fix: surface Firestore errors in UsernameSetup (claim handle button fix)

### DIFF
--- a/src/app/components/username-setup.tsx
+++ b/src/app/components/username-setup.tsx
@@ -17,6 +17,7 @@ export function UsernameSetup({ onComplete }: Props) {
   const [checking, setChecking] = useState(false);
   const [taken, setTaken] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const isValid = USERNAME_REGEX.test(value);
   const canSubmit = isValid && !taken && !checking && !submitting;
@@ -45,11 +46,14 @@ export function UsernameSetup({ onComplete }: Props) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!user || !canSubmit) return;
+    setError(null);
     setSubmitting(true);
     try {
       await saveUsername(user.uid, value);
       onComplete(value);
-    } catch {
+    } catch (err) {
+      console.error("Username claim failed:", err);
+      setError("Something went wrong. Please try again.");
       setSubmitting(false);
     }
   };
@@ -127,6 +131,14 @@ export function UsernameSetup({ onComplete }: Props) {
           >
             {submitting ? "Saving…" : "Claim Handle →"}
           </button>
+          {error && (
+            <p
+              className="text-xs text-center"
+              style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", color: "#FF6A4D" }}
+            >
+              {error}
+            </p>
+          )}
         </form>
 
         <p


### PR DESCRIPTION
Fixes #44

## Summary

- In `username-setup.tsx`, the `catch` block in `handleSubmit` was silently swallowing errors from `saveUsername()`. When the Firestore write failed, the button reset to "Claim Handle →" with no feedback — the "does nothing" symptom.
- Added an `error` state, log the error, and render a message below the button so users know to retry.
- `page.tsx` and `firestore.ts` are correctly wired — no changes needed there.

Generated with [Claude Code](https://claude.ai/code)