### PR TITLE
Fix splash/scroll overlay and implement atomic handle claim with onboarding fixes

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -30,6 +30,14 @@ service cloud.firestore {
       allow update, delete: if false;
     }
 
+    // Handles — immutable once created, readable for uniqueness checks
+    match /handles/{handle} {
+      allow read: if true;
+      allow create: if request.auth != null
+                    && request.resource.data.uid == request.auth.uid;
+      allow update, delete: if false;
+    }
+
     // Duels — participants can read and update their own duels
     match /duels/{duelId} {
       allow read: if request.auth != null

--- a/src/app/components/splash-screen.tsx
+++ b/src/app/components/splash-screen.tsx
@@ -12,11 +12,17 @@ export function SplashScreen({ onComplete }: SplashScreenProps) {
   const [showEntry, setShowEntry] = useState(false);
 
   useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
     // Switch to entry screen when splash fade-out ends (3.6s delay + 0.8s duration)
     const timer = setTimeout(() => {
       setShowEntry(true);
     }, 4400);
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      document.body.style.overflow = previousOverflow;
+    };
   }, []);
 
   if (showEntry) {
@@ -26,6 +32,7 @@ export function SplashScreen({ onComplete }: SplashScreenProps) {
   return (
     <div
       className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-6"
+      aria-hidden="true"
       style={{
         background:
           "radial-gradient(ellipse at 0% 0%, rgba(31,75,255,0.15) 0%, transparent 50%), radial-gradient(ellipse at 100% 100%, rgba(255,106,77,0.15) 0%, transparent 50%), #0B1020",

--- a/src/app/components/user-menu.tsx
+++ b/src/app/components/user-menu.tsx
@@ -23,6 +23,7 @@ type UserMenuProps = {
   onOpenStudy?: () => void;
   onOpenFriends?: () => void;
   activeScreen?: ActiveScreen;
+  handle?: string | null;
 };
 
 const handleChallengeFriend = () => {
@@ -39,6 +40,7 @@ export function UserMenu({
   onOpenStudy,
   onOpenFriends,
   activeScreen = "home",
+  handle = null,
 }: UserMenuProps) {
   const { user, signInWithGoogle, signOut, isGuest, loading } = useAuth();
 
@@ -125,6 +127,14 @@ export function UserMenu({
         <DropdownMenuLabel>
           <div className="flex flex-col space-y-1">
             <p className="text-sm font-medium">{user?.displayName}</p>
+            {handle && (
+              <p
+                className="text-xs font-mono tracking-widest"
+                style={{ color: "rgba(250,250,247,0.5)" }}
+              >
+                @{handle}
+              </p>
+            )}
             <p className="text-xs text-muted-foreground truncate">
               {user?.email}
             </p>

--- a/src/app/components/username-setup.tsx
+++ b/src/app/components/username-setup.tsx
@@ -3,13 +3,13 @@
 
 import React, { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/auth-context";
-import { setUsername as saveUsername, isUsernameTaken } from "@/lib/firestore";
+import { claimHandle, getHandle, isHandleTaken } from "@/lib/firestore";
 
 type Props = {
   onComplete: (username: string) => void;
 };
 
-const USERNAME_REGEX = /^[a-zA-Z0-9_]{3,20}$/;
+const USERNAME_REGEX = /^[a-z0-9_]{3,20}$/;
 
 export function UsernameSetup({ onComplete }: Props) {
   const { user } = useAuth();
@@ -32,7 +32,7 @@ export function UsernameSetup({ onComplete }: Props) {
     setChecking(true);
     const timer = setTimeout(async () => {
       try {
-        const result = await isUsernameTaken(value);
+        const result = await isHandleTaken(value.toLowerCase());
         setTaken(result);
       } catch {
         setTaken(false);
@@ -49,8 +49,21 @@ export function UsernameSetup({ onComplete }: Props) {
     setError(null);
     setSubmitting(true);
     try {
-      await saveUsername(user.uid, value);
-      onComplete(value);
+      const result = await claimHandle(user.uid, value);
+      if (result === "ok") {
+        onComplete(value);
+        return;
+      }
+      if (result === "taken") {
+        setTaken(true);
+        setError("Handle taken. Try another one.");
+      } else if (result === "already_has_handle") {
+        const existingHandle = await getHandle(user.uid);
+        onComplete(existingHandle ?? value);
+      } else {
+        setError("Something went wrong. Please try again.");
+      }
+      setSubmitting(false);
     } catch (err) {
       console.error("Username claim failed:", err);
       setError("Something went wrong. Please try again.");
@@ -98,8 +111,15 @@ export function UsernameSetup({ onComplete }: Props) {
             <input
               type="text"
               value={value}
-              onChange={(e) => setValue(e.target.value.trim())}
-              placeholder="e.g. horacioR"
+              onChange={(e) =>
+                setValue(
+                  e.target.value
+                    .toLowerCase()
+                    .replace(/[^a-z0-9_]/g, "")
+                    .trim()
+                )
+              }
+              placeholder="e.g. horacio_r"
               maxLength={20}
               autoFocus
               autoCapitalize="none"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -84,12 +84,19 @@
 }
 
 @layer base {
+  html,
+  body {
+    min-height: 100%;
+    background-color: #0B1020;
+  }
+
   * {
     @apply border-border;
   }
   body {
     font-family: var(--font-display);
-    @apply bg-background text-foreground;
+    @apply text-foreground;
+    background-color: #0B1020;
     padding-top: env(safe-area-inset-top);
     padding-bottom: env(safe-area-inset-bottom);
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ import { FriendsPanel } from "@/app/components/friends-panel";
 import { SplashScreen } from "@/app/components/splash-screen";
 import { useAuth } from "@/contexts/auth-context";
 import { useState, useEffect, useCallback } from "react";
-import { initializeUserStats, type UserStats } from "@/lib/firestore";
+import { getHandle, initializeUserStats, type UserStats } from "@/lib/firestore";
 import { Heart } from "lucide-react";
 
 export default function Home() {
@@ -22,6 +22,7 @@ export default function Home() {
   const [showStudyMode, setShowStudyMode] = useState(false);
   const [showFriendsPanel, setShowFriendsPanel] = useState(false);
   const [needsUsername, setNeedsUsername] = useState(false);
+  const [currentHandle, setCurrentHandle] = useState<string | null>(null);
   const [felicitationsType, setFelicitationsType] = useState<
     "personal" | "global" | null
   >(null);
@@ -45,14 +46,21 @@ export default function Home() {
         user.photoURL
       ).then((stats) => {
         setUserStats(stats);
-        if (!stats.username) {
-          setNeedsUsername(true);
-        }
+        getHandle(user.uid)
+          .then((handle) => {
+            setCurrentHandle(handle);
+            setNeedsUsername(handle === null);
+          })
+          .catch(() => {
+            setCurrentHandle(null);
+            setNeedsUsername(true);
+          });
       });
     } else {
       // Guest: splash → entry screen handles the initial prompt
       setUserStats(null);
       setNeedsUsername(false);
+      setCurrentHandle(null);
     }
   }, [user, loading]);
 
@@ -202,6 +210,7 @@ export default function Home() {
             onOpenStudy={handleOpenStudy}
             onOpenFriends={handleOpenFriends}
             activeScreen={activeScreen}
+            handle={currentHandle}
           />
         </div>
       </div>
@@ -240,9 +249,10 @@ export default function Home() {
       {/* Username setup modal — shown after first sign-in */}
       {needsUsername && user && (
         <UsernameSetup
-          onComplete={(username) => {
+          onComplete={(handle) => {
             setNeedsUsername(false);
-            setUserStats((prev) => prev ? { ...prev, username } : prev);
+            setCurrentHandle(handle);
+            setUserStats((prev) => (prev ? { ...prev, username: handle, handle } : prev));
           }}
         />
       )}

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -52,6 +52,7 @@ export type UserStats = {
   displayName: string;
   photoURL: string | null;
   username?: string;
+  handle?: string;
   duelsWon?: number;
   duelsLost?: number;
   totalCorrect: number;
@@ -216,6 +217,59 @@ export async function setUsername(uid: string, username: string): Promise<void> 
 export async function isUsernameTaken(username: string): Promise<boolean> {
   const snap = await getDoc(doc(db, "usernames", username.toLowerCase()));
   return snap.exists();
+}
+
+export async function isHandleTaken(handle: string): Promise<boolean> {
+  const snap = await getDoc(doc(db, "handles", handle.toLowerCase()));
+  return snap.exists();
+}
+
+export async function claimHandle(
+  uid: string,
+  handle: string
+): Promise<"ok" | "taken" | "already_has_handle" | "error"> {
+  const normalizedHandle = handle.toLowerCase();
+  const handleRef = doc(db, "handles", normalizedHandle);
+  const userRef = doc(db, "users", uid);
+
+  try {
+    await runTransaction(db, async (tx) => {
+      const handleSnap = await tx.get(handleRef);
+      const userSnap = await tx.get(userRef);
+
+      if (userSnap.exists() && userSnap.data()?.handle) {
+        throw new Error("already_has_handle");
+      }
+
+      if (handleSnap.exists()) {
+        throw new Error("taken");
+      }
+
+      tx.set(handleRef, { uid, createdAt: serverTimestamp() });
+      tx.set(
+        userRef,
+        {
+          handle: normalizedHandle,
+          username: normalizedHandle,
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true }
+      );
+    });
+
+    return "ok";
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "";
+    if (msg === "taken") return "taken";
+    if (msg === "already_has_handle") return "already_has_handle";
+    console.error("claimHandle error:", e);
+    return "error";
+  }
+}
+
+export async function getHandle(uid: string): Promise<string | null> {
+  const snap = await getDoc(doc(db, "users", uid));
+  return snap.exists() ? (snap.data()?.handle ?? null) : null;
 }
 
 export async function getUserByUsername(


### PR DESCRIPTION
### Motivation
- Remove the white/off-brand rectangle and scroll lock left behind after the intro/splash animation by ensuring the overlay does not block document scrolling after it finishes.
- Fix a silent handle-claim failure, skip handle prompt for users who already have a handle, and show the claimed handle in the avatar menu.

### Description
- Restore body scrolling on splash lifecycle by setting `document.body.style.overflow = 'hidden'` during the splash and restoring it on cleanup in `src/app/components/splash-screen.tsx` and mark the overlay `aria-hidden` when appropriate.
- Harden page background and base layout so the brand background is always visible by adjusting `src/app/globals.css` (ensure full-page background color and `min-height` on `html, body`).
- Add atomic handle claim APIs in `src/lib/firestore.ts`: `claimHandle(uid, handle)`, `getHandle(uid)`, and `isHandleTaken(handle)`, and add `handle?: string` to `UserStats`; `claimHandle` uses a Firestore transaction to write `handles/{handle}` and merge the `handle` into `users/{uid}` atomically.
- Add immutable `handles` rules to `firestore.rules` to allow read checks and authenticated `create` operations for uniqueness enforcement.
- Update onboarding and UI: `src/app/page.tsx` now checks `getHandle(user.uid)` on sign-in and only shows the handle prompt when no handle exists, passes `currentHandle` into `UserMenu`, and updates local `userStats` with the handle when set.
- Improve handle setup flow in `src/app/components/username-setup.tsx` to validate/normalize input to lowercase, enforce `/^[a-z0-9_]{3,20}$/`, debounce availability via `isHandleTaken`, call `claimHandle` and handle the returned statuses (`ok`, `taken`, `already_has_handle`, `error`) with appropriate UI feedback.
- Display `@handle` in the avatar dropdown in monospace style in `src/app/components/user-menu.tsx` when a handle is known.

### Testing
- Ran `npm run build` (Next.js production build + static export) and the build completed successfully.
- No automated UI/browser screenshot tests were run in this environment; visual verification should be performed in staging to confirm the splash overlay no longer leaves a white rectangle and scrolling is restored.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6ff02e788329aa58749656b6a98b)