### PR TITLE
Fix handle claim failures and improve onboarding error messages

### DIFF
--- a/src/app/components/username-setup.tsx
+++ b/src/app/components/username-setup.tsx
@@ -60,6 +60,10 @@ export function UsernameSetup({ onComplete }: Props) {
       } else if (result === "already_has_handle") {
         const existingHandle = await getHandle(user.uid);
         onComplete(existingHandle ?? value);
+      } else if (result === "permission_denied") {
+        setError("Handle claim is blocked by Firestore rules. Please contact support.");
+      } else if (result === "auth_required") {
+        setError("Your sign-in expired. Please sign in again and retry.");
       } else {
         setError("Something went wrong. Please try again.");
       }

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -1,6 +1,7 @@
 // src/lib/firestore.ts
 import {
   type DocumentData,
+  type FirestoreError,
   type UpdateData,
   doc,
   getDoc,
@@ -227,25 +228,35 @@ export async function isHandleTaken(handle: string): Promise<boolean> {
 export async function claimHandle(
   uid: string,
   handle: string
-): Promise<"ok" | "taken" | "already_has_handle" | "error"> {
+): Promise<"ok" | "taken" | "already_has_handle" | "auth_required" | "permission_denied" | "error"> {
   const normalizedHandle = handle.toLowerCase();
   const handleRef = doc(db, "handles", normalizedHandle);
+  const usernameRef = doc(db, "usernames", normalizedHandle);
   const userRef = doc(db, "users", uid);
 
   try {
     await runTransaction(db, async (tx) => {
       const handleSnap = await tx.get(handleRef);
+      const usernameSnap = await tx.get(usernameRef);
       const userSnap = await tx.get(userRef);
 
-      if (userSnap.exists() && userSnap.data()?.handle) {
+      const existingUserHandle = userSnap.exists() ? (userSnap.data()?.handle as string | undefined) : undefined;
+      if (existingUserHandle && existingUserHandle !== normalizedHandle) {
         throw new Error("already_has_handle");
       }
 
-      if (handleSnap.exists()) {
+      if (handleSnap.exists() && handleSnap.data()?.uid !== uid) {
         throw new Error("taken");
       }
 
-      tx.set(handleRef, { uid, createdAt: serverTimestamp() });
+      if (!handleSnap.exists()) {
+        tx.set(handleRef, { uid, createdAt: serverTimestamp() });
+      }
+
+      if (!usernameSnap.exists()) {
+        tx.set(usernameRef, { uid });
+      }
+
       tx.set(
         userRef,
         {
@@ -262,6 +273,9 @@ export async function claimHandle(
     const msg = e instanceof Error ? e.message : "";
     if (msg === "taken") return "taken";
     if (msg === "already_has_handle") return "already_has_handle";
+    const firestoreError = e as FirestoreError | null;
+    if (firestoreError?.code === "permission-denied") return "permission_denied";
+    if (firestoreError?.code === "unauthenticated") return "auth_required";
     console.error("claimHandle error:", e);
     return "error";
   }


### PR DESCRIPTION
### Motivation
- Users could not complete handle association: the UI showed "Available!" but `claimHandle` sometimes failed with a generic "Something went wrong", blocking play. 
- Investigation showed race/partial-data states between `handles/{handle}`, `usernames/{handle}`, and `users/{uid}`, plus Firestore permission/auth failures were surfaced only as a generic error.
- The change aims to make handle claiming idempotent, recover from missing companion docs, and surface actionable errors when rules or auth are the root cause.

### Description
- Harden `claimHandle` transaction in `src/lib/firestore.ts` to read `handles/{handle}`, `usernames/{handle}`, and `users/{uid}` together and enforce these rules: preserve a user’s existing permanent handle, only block true conflicts, allow idempotent re-claims by the same UID, create a missing `usernames/{handle}` doc when appropriate, and avoid overwriting conflicting `handles` owned by other UIDs.
- Map Firestore error codes to explicit return values by returning `permission_denied` for Firestore permission issues and `auth_required` for unauthenticated errors from `claimHandle` to allow finer UI handling.
- Update onboarding UI in `src/app/components/username-setup.tsx` to show actionable messages when `claimHandle` returns `permission_denied` or `auth_required` instead of a generic message.

### Testing
- Type-check: ran `npm run typecheck` and the TypeScript checks pass after the changes.
- Lint: attempted `npm run lint` but the Next.js ESLint setup prompted interactively in this non-interactive environment, so automated lint could not complete here.
- Runtime/manual verification: could not delete or modify live Firestore documents from this environment (no admin/CLI access), so the fix was validated by static checks and improved error handling rather than live DB mutations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed77f11438832999363f6c2c776dd7)