### PR TITLE
Ensure handle claims work: deploy Firestore rules/indexes, normalize handles, and tighten claim logic

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -30,3 +30,15 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_VERBUMFLOWAPP }}"
           channelId: live
           projectId: verbumflowapp
+
+      - name: Write Firebase service account key
+        run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_VERBUMFLOWAPP }}' > firebase-service-account.json
+
+      - name: Deploy Firestore rules and indexes
+        run: npx firebase-tools deploy --only firestore:rules,firestore:indexes --project verbumflowapp --non-interactive
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/firebase-service-account.json
+
+      - name: Remove Firebase service account key
+        if: always()
+        run: rm -f firebase-service-account.json

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,8 @@
 {
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
   "hosting": {
     "public": "out",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],

--- a/src/app/components/username-setup.tsx
+++ b/src/app/components/username-setup.tsx
@@ -49,9 +49,10 @@ export function UsernameSetup({ onComplete }: Props) {
     setError(null);
     setSubmitting(true);
     try {
-      const result = await claimHandle(user.uid, value);
+      const normalizedValue = value.toLowerCase();
+      const result = await claimHandle(user.uid, normalizedValue);
       if (result === "ok") {
-        onComplete(value);
+        onComplete(normalizedValue);
         return;
       }
       if (result === "taken") {

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -249,6 +249,10 @@ export async function claimHandle(
         throw new Error("taken");
       }
 
+      if (usernameSnap.exists() && usernameSnap.data()?.uid !== uid) {
+        throw new Error("taken");
+      }
+
       if (!handleSnap.exists()) {
         tx.set(handleRef, { uid, createdAt: serverTimestamp() });
       }


### PR DESCRIPTION
### Motivation
- Users could not successfully claim handles because Firestore security/config mismatches and a collision edge-case allowed inconsistent writes.
- The deploy pipeline only pushed Hosting previously, leaving Firestore rules/indexes out of sync with repo changes and causing `permission-denied` at runtime.
- Handle creation flow also had minor normalization inconsistencies that could cause mismatches between client and DB.

### Description
- Add Firestore mapping to `firebase.json` so `firestore.rules` and `firestore.indexes.json` are part of the project config.
- Update the merge deploy workflow (`.github/workflows/firebase-hosting-merge.yml`) to write a service-account key in CI, deploy Firestore `rules` and `indexes`, and then remove the key to ensure Firestore security config is applied on each merge.
- Harden `claimHandle` in `src/lib/firestore.ts` to treat an existing `usernames/{handle}` owned by a different UID as `taken`, preventing collisions and inconsistent state.
- Normalize submitted handles to lowercase in `src/app/components/username-setup.tsx` so the client always submits the canonical form and the UI callback receives the normalized value.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully.
- `npm run lint` could not be run non-interactively in this environment because Next.js ESLint setup prompts for configuration, so lint was not executed here.
- CI must run the updated workflow on merge to actually deploy Firestore rules/indexes (this is required to fix the production `permission-denied` symptoms).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed7e10b7488329a9ebc15859c9791e)