### PR TITLE
Improve mobile-safe spacing for top navigation and Friends header

### DIFF
--- a/src/app/components/friends-panel.tsx
+++ b/src/app/components/friends-panel.tsx
@@ -215,7 +215,10 @@ export function FriendsPanel({
         aria-label="Friends"
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-5 pt-5 pb-4 border-b border-white/10">
+        <div
+          className="flex items-center justify-between border-b border-white/10 px-5 pb-4"
+          style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 16px)" }}
+        >
           <h2
             className="text-lg font-bold text-white"
             style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}

--- a/src/app/components/user-menu.tsx
+++ b/src/app/components/user-menu.tsx
@@ -87,18 +87,24 @@ export function UserMenu({
   if (loading) {
     return (
       <>
-        <div className="flex justify-center gap-8">
+        <div className="mx-auto flex w-full max-w-sm items-center justify-center gap-3 px-3 sm:gap-4 sm:px-4">
           {[...Array(5)].map((_, i) => (
             <div key={i} className="h-11 w-11 rounded-full bg-white/10 animate-pulse" />
           ))}
         </div>
-        <div className="fixed top-3 right-3 z-50 h-10 w-10 rounded-full bg-white/20 animate-pulse" />
+        <div
+          className="fixed z-50 h-11 w-11 rounded-full bg-white/20 animate-pulse"
+          style={{
+            top: "calc(env(safe-area-inset-top, 0px) + 12px)",
+            right: "calc(env(safe-area-inset-right, 0px) + 12px)",
+          }}
+        />
       </>
     );
   }
 
   const navRow = (
-    <div className="flex justify-center gap-8 items-center">
+    <div className="mx-auto flex w-full max-w-sm items-center justify-center gap-3 px-3 sm:gap-4 sm:px-4">
       {navItems.map(({ icon: Icon, label, onClick, screen }) => {
         if (!onClick) return null;
         const isActive = screen !== undefined && activeScreen === screen;
@@ -106,7 +112,7 @@ export function UserMenu({
           <button
             key={label}
             onClick={onClick}
-            className="p-3 rounded-full text-white hover:bg-white/10 transition-colors"
+            className="flex h-11 w-11 items-center justify-center rounded-full text-white hover:bg-white/10 transition-colors"
             style={{ opacity: isActive ? 1 : 0.4 }}
             title={label}
             aria-label={label}
@@ -121,7 +127,7 @@ export function UserMenu({
         <div className="relative">
           <button
             onClick={() => setFriendsPanelOpen(true)}
-            className="p-3 rounded-full text-white hover:bg-white/10 transition-colors"
+            className="flex h-11 w-11 items-center justify-center rounded-full text-white hover:bg-white/10 transition-colors"
             style={{ opacity: friendsPanelOpen ? 1 : 0.4 }}
             title="Friends"
             aria-label="Friends"
@@ -144,7 +150,11 @@ export function UserMenu({
   const avatarEl = isGuest ? (
     <button
       onClick={signInWithGoogle}
-      className="fixed top-3 right-3 z-50 h-10 w-10 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none"
+      className="fixed z-50 flex h-11 w-11 items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none"
+      style={{
+        top: "calc(env(safe-area-inset-top, 0px) + 12px)",
+        right: "calc(env(safe-area-inset-right, 0px) + 12px)",
+      }}
       title="Sign in with Google"
       aria-label="Sign in with Google"
     >
@@ -154,7 +164,11 @@ export function UserMenu({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
-          className="fixed top-3 right-3 z-50 h-10 w-10 rounded-full border-2 border-white/30 overflow-hidden hover:border-white/60 transition-colors focus:outline-none"
+          className="fixed z-50 h-11 w-11 overflow-hidden rounded-full border-2 border-white/30 transition-colors hover:border-white/60 focus:outline-none"
+          style={{
+            top: "calc(env(safe-area-inset-top, 0px) + 12px)",
+            right: "calc(env(safe-area-inset-right, 0px) + 12px)",
+          }}
           title={user?.displayName ?? "Account"}
           aria-label="Account menu"
         >


### PR DESCRIPTION
### Motivation
- Fix cramped or overly spread top navigation icons on mobile so the six action icons are centered, visually balanced, and easier to tap. 
- Move the avatar/login control away from the hard screen corner so it doesn’t collide with phone chrome or device notches and is reliably tappable. 
- Ensure the Friends panel header respects device safe areas so the title and close control are not obscured by phone UI elements.

### Description
- Centered and constrained the top nav icon row using a centered container with `max-w-sm`, reduced horizontal gaps, and horizontal padding to avoid edge-to-edge stretching in `src/app/components/user-menu.tsx`. 
- Standardized top nav and friends button touch targets to `44x44` (`h-11 w-11`) and updated button markup for consistent hit areas in `src/app/components/user-menu.tsx`. 
- Repositioned avatar/login button and loading placeholder using safe-area-aware offsets via `env(safe-area-inset-top)` and `env(safe-area-inset-right)` so the control is inset from the screen corner in `src/app/components/user-menu.tsx`. 
- Increased top padding of the Friends panel header to include the device safe-area inset so the `Friends` title and close button are not hidden by phone chrome in `src/app/components/friends-panel.tsx`.

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm run typecheck` and TypeScript check passed with no errors. 
- `npm run lint` could not be run non-interactively because Next.js ESLint setup prompted for configuration in this environment, so lint was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4b8c8334832999608f7ad834a38b)