### PR TITLE
Fix friendship flow: remove unauthorized profile writes and add Firestore index

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,19 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "friendships",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "users",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -390,10 +390,6 @@ export async function acceptFriendRequest(currentUid: string, otherUid: string):
     if (data.initiator === currentUid) throw new Error("cannot_accept_own");
     if (data.status === "accepted") return;
     tx.update(ref, { status: "accepted", updatedAt: serverTimestamp() });
-    const userRef = doc(db, "users", currentUid);
-    const otherRef = doc(db, "users", otherUid);
-    tx.update(userRef, { friendCount: increment(1) });
-    tx.update(otherRef, { friendCount: increment(1) });
   });
 }
 
@@ -402,12 +398,7 @@ export async function removeFriendship(currentUid: string, otherUid: string): Pr
   const ref = doc(db, "friendships", id);
   const snap = await getDoc(ref);
   if (!snap.exists()) return;
-  const data = snap.data() as Friendship;
   await deleteDoc(ref);
-  if (data.status === "accepted") {
-    await updateDoc(doc(db, "users", currentUid), { friendCount: increment(-1) });
-    await updateDoc(doc(db, "users", otherUid), { friendCount: increment(-1) });
-  }
 }
 
 export async function getUserFriendships(uid: string): Promise<(Friendship & { id: string })[]> {


### PR DESCRIPTION
### Motivation
- Accepting/removing friendships could fail because client code attempted to write `friendCount` on both users while Firestore rules only allow a user to write their own `/users/{userId}` document, causing `permission-denied` and a broken friend flow.
- The real-time pending-request listener query (`where("users", "array-contains", uid)` + `where("status", "==", "pending")`) can require a composite index in some environments and may surface "requires an index" errors if not deployed.

### Description
- Removed cross-user profile updates from the friendship flow by eliminating client-side `friendCount` updates in `acceptFriendRequest` and `removeFriendship` in `src/lib/firestore.ts` so accept/remove no longer perform unauthorized writes.
- Added a composite index to `firestore.indexes.json` for the `friendships` collection group to support queries with `users` (`array-contains`) and `status` (`ASCENDING`).
- Left legacy `friends` subcollection helpers untouched and recommended moving `friendCount` maintenance to a trusted backend (Cloud Functions or server-side trigger) if the app needs persistent counts.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully.
- Ran `npm run lint` which did not complete in this environment due to the interactive Next.js ESLint setup prompt. Please run lint locally or in CI to finish configuration and verify style rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee9502208c83299a908990a93aee18)