### PR TITLE
Friend request accept/reject and friend duels (send/accept/reject/enter)

### DIFF
--- a/src/app/components/friends-panel.tsx
+++ b/src/app/components/friends-panel.tsx
@@ -8,8 +8,16 @@ import {
   getUserFriendships,
   sendFriendRequest,
   acceptFriendRequest,
+  rejectFriendRequest,
   removeFriendship,
   getFriendCodeOwner,
+  getPendingDuels,
+  getActiveDuels,
+  sendDuelRequest,
+  acceptDuel,
+  rejectDuel,
+  type DuelRequest,
+  type GameMode,
   type Friendship,
 } from "@/lib/firestore";
 import { getDoc, doc } from "firebase/firestore";
@@ -22,6 +30,7 @@ type FriendsPanelProps = {
   currentUserFriendCode: string;
   pendingAddFriendCode: string;
   onPendingCodeConsumed: () => void;
+  onStartDuel: (duel: { duelId: string; verbSeed: number }) => void;
 };
 
 type UserData = {
@@ -40,6 +49,7 @@ export function FriendsPanel({
   currentUserFriendCode,
   pendingAddFriendCode,
   onPendingCodeConsumed,
+  onStartDuel,
 }: FriendsPanelProps) {
   const [activeTab, setActiveTab] = useState<TabId>("friends");
   const [friendships, setFriendships] = useState<(Friendship & { id: string })[]>([]);
@@ -50,6 +60,9 @@ export function FriendsPanel({
   const [addCode, setAddCode] = useState("");
   const [addStatus, setAddStatus] = useState<AddStatus>("idle");
   const [addError, setAddError] = useState("");
+  const [flashMessage, setFlashMessage] = useState("");
+  const [pendingDuels, setPendingDuels] = useState<DuelRequest[]>([]);
+  const [activeDuels, setActiveDuels] = useState<DuelRequest[]>([]);
   const addInputRef = useRef<HTMLInputElement>(null);
 
   const fetchUserData = useCallback(async (uid: string) => {
@@ -85,12 +98,24 @@ export function FriendsPanel({
         ),
       ];
       await Promise.all(otherUids.map(fetchUserData));
+      const [pending, active] = await Promise.all([
+        getPendingDuels(currentUid),
+        getActiveDuels(currentUid),
+      ]);
+      setPendingDuels(pending);
+      setActiveDuels(active);
     } catch (err) {
       console.error("Failed to load friendships:", err);
     } finally {
       setDataLoading(false);
     }
   }, [currentUid, fetchUserData]);
+
+  useEffect(() => {
+    if (!flashMessage) return;
+    const t = setTimeout(() => setFlashMessage(""), 2600);
+    return () => clearTimeout(t);
+  }, [flashMessage]);
 
   useEffect(() => {
     if (open && currentUid) {
@@ -124,19 +149,54 @@ export function FriendsPanel({
   const handleAccept = async (f: Friendship & { id: string }) => {
     try {
       await acceptFriendRequest(currentUid, getOtherUid(f));
+      setFlashMessage("Friend request accepted. Let’s conjugate together! 🇫🇷");
       await loadFriendships();
     } catch (err) {
       console.error("Failed to accept friend request:", err);
+    }
+  };
+  const handleReject = async (f: Friendship & { id: string }) => {
+    try {
+      await rejectFriendRequest(currentUid, getOtherUid(f));
+      setFlashMessage("Friend request declined.");
+      await loadFriendships();
+    } catch (err) {
+      console.error("Failed to reject friend request:", err);
     }
   };
 
   const handleRemove = async (f: Friendship & { id: string }) => {
     try {
       await removeFriendship(currentUid, getOtherUid(f));
+      setFlashMessage("Friend removed.");
       await loadFriendships();
     } catch (err) {
       console.error("Failed to remove friendship:", err);
     }
+  };
+
+  const getActiveDuelForFriend = (friendUid: string) =>
+    activeDuels.find((d) =>
+      (d.challengerUid === currentUid && d.challengedUid === friendUid) ||
+      (d.challengedUid === currentUid && d.challengerUid === friendUid)
+    );
+
+  const handleSendDuel = async (friendUid: string, mode: GameMode) => {
+    await sendDuelRequest(currentUid, friendUid, Math.floor(Math.random() * 1_000_000_000), mode);
+    setFlashMessage(`${mode === "classic" ? "Classic" : "Random"} duel sent! ⚔️`);
+    await loadFriendships();
+  };
+
+  const handleAcceptDuel = async (duelId: string) => {
+    await acceptDuel(duelId);
+    setFlashMessage("Duel accepted. May the best verb champion win! 🥖");
+    await loadFriendships();
+  };
+
+  const handleRejectDuel = async (duelId: string) => {
+    await rejectDuel(duelId);
+    setFlashMessage("Duel request declined.");
+    await loadFriendships();
   };
 
   const handleAddFriend = async () => {
@@ -214,6 +274,11 @@ export function FriendsPanel({
         role="dialog"
         aria-label="Friends"
       >
+        {flashMessage && (
+          <div className="mx-4 mt-3 rounded-lg px-3 py-2 text-xs text-white" style={{ background: "rgba(31,75,255,0.85)" }}>
+            {flashMessage}
+          </div>
+        )}
         {/* Header */}
         <div
           className="flex items-center justify-between border-b border-white/10 px-5 pb-4"
@@ -322,6 +387,20 @@ export function FriendsPanel({
                       >
                         <UserMinus size={16} />
                       </button>
+                      {getActiveDuelForFriend(otherUid) ? (
+                        <button
+                          onClick={() => onStartDuel(getActiveDuelForFriend(otherUid)!)}
+                          className="px-3 py-1.5 rounded-lg text-xs font-bold text-white"
+                          style={{ backgroundColor: "#1F4BFF", fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+                        >
+                          Enter duel
+                        </button>
+                      ) : (
+                        <div className="flex gap-1">
+                          <button onClick={() => handleSendDuel(otherUid, "classic")} className="px-2 py-1 rounded-lg text-[10px] font-bold text-white/90" style={{ backgroundColor: "rgba(31,75,255,0.8)" }}>Classic duel</button>
+                          <button onClick={() => handleSendDuel(otherUid, "random")} className="px-2 py-1 rounded-lg text-[10px] font-bold text-white/90" style={{ backgroundColor: "rgba(255,106,77,0.8)" }}>Random duel</button>
+                        </div>
+                      )}
                     </div>
                   );
                 })
@@ -402,12 +481,26 @@ export function FriendsPanel({
                               fontFamily: "'Plus Jakarta Sans', sans-serif",
                             }}
                           >
-                            Decline
+                            Remove
                           </button>
                         </div>
                       </div>
                     );
                   })
+                )}
+                {pendingDuels.length > 0 && (
+                  <div className="mt-4 space-y-2">
+                    <p className="text-xs text-white/50">Duel requests</p>
+                    {pendingDuels.map((duel) => (
+                      <div key={duel.duelId} className="rounded-xl p-3 border border-white/10 bg-white/5">
+                        <p className="text-sm text-white">{duel.challengerUsername} challenged you ({duel.mode ?? "classic"})</p>
+                        <div className="mt-2 flex gap-2">
+                          <button onClick={() => handleAcceptDuel(duel.duelId)} className="px-3 py-1.5 rounded-lg text-xs font-bold text-white" style={{ background: "#1F4BFF" }}>Accept</button>
+                          <button onClick={() => handleRejectDuel(duel.duelId)} className="px-3 py-1.5 rounded-lg text-xs font-bold text-white/70" style={{ background: "rgba(255,255,255,0.12)" }}>Reject</button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
                 )}
               </div>
 
@@ -463,7 +556,7 @@ export function FriendsPanel({
                           </p>
                         </div>
                         <button
-                          onClick={() => handleRemove(f)}
+                            onClick={() => handleReject(f)}
                           className="px-3 py-1.5 rounded-lg text-white/60 text-xs font-bold"
                           style={{
                             backgroundColor: "rgba(255,255,255,0.08)",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import { FriendsPanel } from "@/app/components/friends-panel";
 import { SplashScreen } from "@/app/components/splash-screen";
 import { useAuth } from "@/contexts/auth-context";
 import { useState, useEffect, useCallback } from "react";
-import { initializeUserStats, type UserStats } from "@/lib/firestore";
+import { initializeUserStats, submitDuelScore, type UserStats } from "@/lib/firestore";
 import { collection, query, where, onSnapshot } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { Heart } from "lucide-react";
@@ -30,6 +30,8 @@ export default function Home() {
   const [userStats, setUserStats] = useState<UserStats | null>(null);
   const [showHomeInterrupt, setShowHomeInterrupt] = useState(false);
   const [currentGameState, setCurrentGameState] = useState<"idle" | "playing" | "lost">("idle");
+  const [duelMode, setDuelMode] = useState<{ duelId: string; verbSeed: number } | null>(null);
+  const [duelResultMessage, setDuelResultMessage] = useState("");
   const { user, loading, friendCode } = useAuth();
 
   // Manage onboarding visibility and user stats based on auth state
@@ -252,9 +254,33 @@ export default function Home() {
             onHomeInterruptDismiss={() => setShowHomeInterrupt(false)}
             onGoHome={() => setShowHomeInterrupt(false)}
             onGameStateChange={setCurrentGameState}
+            duelMode={duelMode ? {
+              duelId: duelMode.duelId,
+              totalQuestions: 20,
+              verbSeed: duelMode.verbSeed,
+              onComplete: async (score) => {
+                if (!user || !duelMode) return;
+                const result = await submitDuelScore(duelMode.duelId, user.uid, score);
+                if (result.status === "completed") {
+                  setDuelResultMessage(
+                    result.winnerId === user.uid
+                      ? "Victoire ! You won the duel! 🏆"
+                      : "Good fight! You lost this duel — rematch soon? ⚔️"
+                  );
+                } else {
+                  setDuelResultMessage("Score submitted. Waiting for your friend.");
+                }
+                setDuelMode(null);
+              },
+            } : undefined}
           />
         </div>
       </div>
+      {duelResultMessage && (
+        <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 rounded-xl px-4 py-2 text-sm text-white bg-[#1F4BFF]/90">
+          {duelResultMessage}
+        </div>
+      )}
 
       {/* Footer — always at bottom, never overlapping */}
       <footer className="w-full text-center text-xs text-white/80 drop-shadow-sm pt-4">
@@ -280,6 +306,10 @@ export default function Home() {
           currentUserFriendCode={friendCode}
           pendingAddFriendCode={pendingAddFriendCode}
           onPendingCodeConsumed={() => setPendingAddFriendCode("")}
+          onStartDuel={(duel) => {
+            setFriendsPanelOpen(false);
+            setDuelMode(duel);
+          }}
         />
       )}
 

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -32,7 +32,8 @@ export type DuelRequest = {
   challengerUsername: string;
   challengedUid: string;
   challengedUsername: string;
-  status: "pending" | "accepted" | "completed";
+  status: "pending" | "accepted" | "rejected" | "completed";
+  mode?: GameMode;
   verbSeed: number;
   challengerScore: number | null;
   challengedScore: number | null;
@@ -79,7 +80,7 @@ export type UserStats = {
 
 export type Friendship = {
   users: [string, string];
-  status: "pending" | "accepted";
+  status: "pending" | "accepted" | "rejected";
   initiator: string;
   createdAt: Timestamp;
   updatedAt: Timestamp;
@@ -407,6 +408,18 @@ export async function acceptFriendRequest(currentUid: string, otherUid: string):
   });
 }
 
+export async function rejectFriendRequest(currentUid: string, otherUid: string): Promise<void> {
+  const id = friendshipId(currentUid, otherUid);
+  const ref = doc(db, "friendships", id);
+  await runTransaction(db, async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists()) throw new Error("not_found");
+    const data = snap.data() as Friendship;
+    if (data.initiator === currentUid) throw new Error("cannot_reject_own");
+    tx.update(ref, { status: "rejected", updatedAt: serverTimestamp() });
+  });
+}
+
 export async function removeFriendship(currentUid: string, otherUid: string): Promise<void> {
   const id = friendshipId(currentUid, otherUid);
   const ref = doc(db, "friendships", id);
@@ -457,7 +470,8 @@ export async function getFriends(uid: string): Promise<FriendEntry[]> {
 export async function sendDuelRequest(
   challengerUid: string,
   challengedUid: string,
-  verbSeed: number
+  verbSeed: number,
+  mode: GameMode
 ): Promise<string> {
   const [challengerSnap, challengedSnap] = await Promise.all([
     getDoc(doc(db, "users", challengerUid)),
@@ -470,6 +484,7 @@ export async function sendDuelRequest(
     challengedUid,
     challengedUsername: challengedSnap.data()?.username ?? "unknown",
     status: "pending",
+    mode,
     verbSeed,
     challengerScore: null,
     challengedScore: null,
@@ -483,6 +498,10 @@ export async function sendDuelRequest(
 
 export async function acceptDuel(duelId: string): Promise<void> {
   await updateDoc(doc(db, "duels", duelId), { status: "accepted" });
+}
+
+export async function rejectDuel(duelId: string): Promise<void> {
+  await updateDoc(doc(db, "duels", duelId), { status: "rejected" });
 }
 
 export async function submitDuelScore(


### PR DESCRIPTION
### Motivation
- Ensure friend relationships require an explicit accept or reject decision instead of auto-adding, and allow removing friends. 
- Provide clear one-time on-screen feedback after friend or duel actions so users know when a request is accepted, rejected, removed, or sent. 
- Add friend-to-friend duels with full lifecycle (send classic/random, accept/reject, enter active duel, submit scores and record win/loss) so friends can compete fairly.

### Description
- Updated Firestore types and APIs in `src/lib/firestore.ts` to add `rejected` states and `mode` metadata, and added `rejectFriendRequest` and `rejectDuel` functions while making `sendDuelRequest` accept a `mode` parameter. 
- Expanded `src/app/components/friends-panel.tsx` to load pending/active duels, show one-time flash messages, accept/reject incoming friend requests, allow cancelling sent requests, send `classic` or `random` duel requests, accept/reject incoming duels, and show an `Enter duel` button when an active duel exists instead of the send buttons. 
- Integrated duel session entry into `src/app/page.tsx` by adding a `duelMode` state, passing a `duelMode` object into `ConjugationPractice`, and wiring the duel completion callback to `submitDuelScore` to record scores and surface a user-facing result message (win/lose/waiting). 
- Kept UI consistent with existing tone and styling and avoided changing the underlying practice/duel question generation logic other than providing the `verbSeed` and duel lifecycle hooks.

### Testing
- Ran type checking with `npm run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14ef55b30832881e6245c3654c190)