### PR TITLE
Fix frozen gameplay loading and pin duel result message

### DIFF
--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -208,6 +208,7 @@ export function ConjugationPractice({
   const [fillInTheBlankQueue, setFillInTheBlankQueue] = useState<Question[]>([]);
   const [recentRandomPairs, setRecentRandomPairs] = useState<string[]>([]);
   const [currentQuestion, setCurrentQuestion] = useState<CurrentQuestion | null>(null);
+  const [questionLoadAttempts, setQuestionLoadAttempts] = useState(0);
   const [userAnswer, setUserAnswer] = useState("");
   const [feedback, setFeedback] = useState<Feedback>(null);
   const [isAnswered, setIsAnswered] = useState(false);
@@ -662,6 +663,29 @@ export function ConjugationPractice({
       setKey((k) => k + 1);
     }
   }, [filteredQuestions.length, gameState]);
+
+
+  // Prevent frozen loading card: if a question fails to initialize quickly while playing, force-generate one.
+  useEffect(() => {
+    if (gameState !== "playing" || currentQuestion || showLevelUp) return;
+
+    const fallbackId = setTimeout(() => {
+      const fallback = pickRandomQuestion([], 0);
+      setGameMode((prev) => (prev === "classic" && filteredClassicVerbTensePairs.length === 0 ? "random" : prev));
+      setCurrentQuestion(getQuestionDetails(fallback, "multiple-choice"));
+      setRecentRandomPairs([`${fallback.verb}|${fallback.pronoun}`]);
+      setQuestionLoadAttempts((prev) => prev + 1);
+    }, 1200);
+
+    return () => clearTimeout(fallbackId);
+  }, [
+    currentQuestion,
+    gameState,
+    getQuestionDetails,
+    pickRandomQuestion,
+    filteredClassicVerbTensePairs.length,
+    showLevelUp,
+  ]);
 
   // Timer: reset and run on each new question, pause when answered or not playing
   useEffect(() => {
@@ -1845,8 +1869,25 @@ export function ConjugationPractice({
               className="mt-4"
               style={{ color: "#0B1020", fontFamily: "'Plus Jakarta Sans', sans-serif" }}
             >
-              Loading Verbs...
+              Preparing your next question…
             </CardTitle>
+            {questionLoadAttempts > 0 && (
+              <p className="mt-2 text-xs text-center text-[#0B1020]/60">
+                Recovered from a loading hiccup.
+              </p>
+            )}
+            <Button
+              onClick={() => {
+                const fallback = pickRandomQuestion([], 0);
+                setCurrentQuestion(getQuestionDetails(fallback, "multiple-choice"));
+                setRecentRandomPairs([`${fallback.verb}|${fallback.pronoun}`]);
+                setKey((k) => k + 1);
+              }}
+              className="mt-4 bg-[#1F4BFF] hover:bg-[#1637CC] text-white"
+              style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+            >
+              Continue now
+            </Button>
           </Card>
         )
       )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -277,7 +277,7 @@ export default function Home() {
         </div>
       </div>
       {duelResultMessage && (
-        <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 rounded-xl px-4 py-2 text-sm text-white bg-[#1F4BFF]/90">
+        <div className="w-full max-w-md mt-3 rounded-xl px-4 py-2 text-sm text-white bg-[#1F4BFF]/90 text-center">
           {duelResultMessage}
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Prevent the app from getting stuck on an infinite loading/spinner when starting or transitioning game rounds so players can begin playing immediately.
- Ensure duel completion/wait messages do not float above content or follow scrolling, keeping the UI stable and readable.

### Description
- Added a fallback watchdog `useEffect` in `ConjugationPractice` that auto-generates a deterministic fallback question after 1.2s when the app is `playing` but no `currentQuestion` is set, preventing frozen loading states.
- Introduced `questionLoadAttempts` state and updated the loading card to show a recovery message and a manual `Continue now` `Button` which forces generation of a fallback question immediately.
- Changed duel result/wait bubble in `src/app/page.tsx` from a `fixed` floating overlay to an in-flow block (`w-full max-w-md ... text-center`) so the message stays static in layout and doesn't overlay or move while scrolling.
- Kept the changes minimal and defensive so the normal question-generation flow is untouched except for the recovery path and UX affordances.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully.
- Attempted `npm run lint` but it could not run non-interactively due to Next.js ESLint initial setup prompting for configuration, so lint was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17c7687388328bd64f99cc32e7c58)