### PR TITLE
Fix multiple-choice options to use same pronoun across tenses

### DIFF
--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -306,13 +306,16 @@ export function ConjugationPractice({
 
       if (currentMode === "multiple-choice") {
         const wrongOptions: string[] = [];
-        const allConjugationsForVerb = new Set(
-          Object.values(verbData[verb]).flatMap((p) => Object.values(p))
-        );
+        const allTensesForVerb = verbData[verb] ?? {};
+        const potentialWrongOptions = Array.from(
+          new Set(
+            Object.entries(allTensesForVerb)
+              .filter(([tenseName]) => tenseName !== tense)
+              .map(([, pronounMap]) => pronounMap[pronoun])
+              .filter((candidate): candidate is string => Boolean(candidate))
+          )
+        ).filter((c) => c !== correctAnswer);
 
-        const potentialWrongOptions = Array.from(allConjugationsForVerb).filter(
-          (c) => c !== correctAnswer && c
-        );
         const shuffledWrongOptions = shuffleArray(potentialWrongOptions);
         for (const option of shuffledWrongOptions) {
           if (wrongOptions.length >= 3) break;


### PR DESCRIPTION
### Motivation
- Multiple-choice distractors were being drawn from any conjugation of the verb, which could mix pronouns (e.g., question shows `je` but options include `tu`/`ils`), creating confusing practice items. 
- The intended UX is to quiz the same subject pronoun across different tenses of the same verb so learners compare tense forms, not different pronouns.

### Description
- Updated `getQuestionDetails` in `src/app/components/conjugation-practice.tsx` to generate MC wrong options from the same `verb` and same `pronoun` across other tenses instead of all pronouns. 
- The new logic builds `potentialWrongOptions` by collecting the mapped conjugation for the current `pronoun` from other tenses and filters out the `correctAnswer` and falsy values. 
- Kept the existing safe fallback that fills any remaining MC slots from the global `allConjugations` pool when same-pronoun cross-tense distractors are insufficient. 

### Testing
- Ran `npm run build`, which completed successfully and produced a compiled production build. 
- Attempted `npm run lint`, but the Next.js ESLint setup prompted interactively so linting could not be completed non-interactively in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18014df9c8328ab8f19285dc67232)