### PR TITLE
Align answer options with displayed verb/pronoun prompts

### DIFF
--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -324,16 +324,11 @@ export function ConjugationPractice({
           }
         }
 
-        const remainingSlots = 3 - wrongOptions.length;
-        if (remainingSlots > 0) {
-          const globalWrongOptions = shuffleArray(
-            allConjugations.filter(
-              (c) => c !== correctAnswer && !wrongOptions.includes(c)
-            )
-          ).slice(0, remainingSlots);
-          wrongOptions.push(...globalWrongOptions);
-        }
-        const options = shuffleArray([correctAnswer, ...wrongOptions]);
+        // Keep options consistent with the displayed prompt:
+        // - same verb
+        // - same subject pronoun
+        // The only thing that varies is the tense/conjugation form.
+        const options = shuffleArray([correctAnswer, ...wrongOptions.slice(0, 3)]);
         return { verb, tense, pronoun, correctAnswer, options, rule, tip };
       } else {
         return { verb, tense, pronoun, correctAnswer, rule, tip };
@@ -1759,13 +1754,22 @@ export function ConjugationPractice({
                 </div>
               ) : (
                 <form onSubmit={handleFormSubmit} className="space-y-4">
+                  <p
+                    className="text-center text-xs sm:text-sm"
+                    style={{
+                      color: "rgba(11,16,32,0.65)",
+                      fontFamily: "'Plus Jakarta Sans', sans-serif",
+                    }}
+                  >
+                    Write only the conjugated verb. Do not include the pronoun.
+                  </p>
                   <Input
                     ref={inputRef}
                     type="text"
                     value={userAnswer}
                     onChange={(e) => setUserAnswer(e.target.value)}
                     disabled={isAnswered}
-                    placeholder="Type the conjugation..."
+                    placeholder="Write only the conjugated verb (no pronoun)..."
                     className={cn("text-center text-lg h-14", getInputClass())}
                     autoCapitalize="none"
                     autoComplete="off"


### PR DESCRIPTION
### Motivation
- Multiple-choice options could include conjugations from unrelated verbs or pronouns, causing mismatched prompts and answers in all game modes. 
- Fill-in-the-blank instructions were ambiguous about whether to include the pronoun, which led to inconsistent user input and grading.
- The goal is to make options always correspond to the shown verb and subject pronoun and make typing instructions explicit so answers are consistent across classic/random/competitive/duel flows.

### Description
- Constrained multiple-choice distractors in `getQuestionDetails` so wrong options are drawn only from the same `verb` and the same `pronoun`, and limited to at most three distractors. 
- Removed the previous global fallback pool of unrelated conjugations so options can no longer come from other verbs/pronouns. 
- Added an explicit helper paragraph and updated the input `placeholder` in the fill-in-the-blank UI to say `Write only the conjugated verb (no pronoun)...` so users know to type only the verb form.
- Changes are implemented in `src/app/components/conjugation-practice.tsx` where question generation and UI rendering are handled.

### Testing
- `npm run lint` could not complete non-interactively because the environment triggered an interactive ESLint configuration prompt. 
- `npm run build -- --no-lint` completed successfully and produced a compiled production build without errors. 
- The modified component was inspected locally and the build verified that the updated question generation and UI compile correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18314b0508328b0b899cb9a9f2818)