### PR TITLE
Fix multiple-choice distractors to match prompted verb/pronoun

### DIFF
--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -303,18 +303,18 @@ export function ConjugationPractice({
       if (currentMode === "multiple-choice") {
         const allTensesForVerb = verbData[verb] ?? {};
 
-        const sameVerbWrongOptions = Object.entries(allTensesForVerb)
-          .filter(([tenseName]) => tenseName !== tense)
+        const sameVerbPronounCandidates = Object.entries(allTensesForVerb)
           .map(([, pronounMap]) => pronounMap[pronoun])
           .filter((candidate): candidate is string => Boolean(candidate));
 
-        const sameTenseWrongOptions = Object.values(verbData)
-          .map((tenses) => tenses[tense]?.[pronoun])
-          .filter((candidate): candidate is string => Boolean(candidate));
+        const uniqueSameVerbPronounOptions = Array.from(new Set(sameVerbPronounCandidates));
+        const uniqueWrongOptions = uniqueSameVerbPronounOptions.filter(
+          (candidate) => candidate !== correctAnswer
+        );
 
-        const uniqueWrongOptions = Array.from(
-          new Set([...sameVerbWrongOptions, ...sameTenseWrongOptions])
-        ).filter((candidate) => candidate !== correctAnswer);
+        if (uniqueWrongOptions.length < 3) {
+          return null;
+        }
 
         const wrongOptions = shuffleArray(uniqueWrongOptions).slice(0, 3);
         const options = shuffleArray([correctAnswer, ...wrongOptions]);


### PR DESCRIPTION
### Motivation
- Users were seeing multiple-choice options drawn from different verbs and tenses, causing grammatically or contextually incorrect choices for the prompted verb/pronoun. 
- The app must always present four options that are the same verb conjugated in different tenses for the same pronoun so learners are not confused by unrelated verbs.

### Description
- Changed MC distractor generation in `src/app/components/conjugation-practice.tsx` so wrong options are sourced only from the same prompted `verb` and the same `pronoun` across other tenses. 
- Ensured the MC generator builds a strict 4-option set (1 correct + 3 distinct wrong options) and returns `null` for questions where 3 valid distractors cannot be produced, forcing selection of a different question. 
- Left existing classic-mode pronoun ordering and the fill-in normalization behavior intact since they already enforce `je`-first cycles and strip pronouns from user input respectively. 

### Testing
- Attempted to run the project linter with `npm run lint`, but the command could not complete non-interactively due to a first-run ESLint configuration prompt, so automated linting did not finish (no passing/validation result produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27948c81483288759611e55ca2909)