### PR TITLE
Show English translation next to French verb in quiz header

### DIFF
--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -7,6 +7,7 @@ import {
   verbs as allVerbs,
   allConjugations,
   getRule,
+  getVerbTranslationEn,
 } from "@/lib/verbs";
 import { Button } from "@/components/ui/button";
 import {
@@ -1192,6 +1193,9 @@ export function ConjugationPractice({
 
   // Determine which input mode to show (force multiple-choice in practiceOnly and duelMode)
   const displayMode: PracticeMode = practiceOnly || duelMode ? "multiple-choice" : mode;
+  const currentVerbTranslation = currentQuestion
+    ? getVerbTranslationEn(currentQuestion.verb)
+    : null;
 
   return (
     <div className="space-y-3">
@@ -1753,6 +1757,11 @@ export function ConjugationPractice({
                 }}
               >
                 {currentQuestion.verb}
+                {currentVerbTranslation ? (
+                  <span className="ml-2 text-base sm:text-lg font-semibold text-slate-500 align-middle">
+                    ({currentVerbTranslation})
+                  </span>
+                ) : null}
               </CardTitle>
               <CardDescription className="text-center">
                 <Badge

--- a/src/lib/verbs.ts
+++ b/src/lib/verbs.ts
@@ -105,6 +105,16 @@ export const verbData: VerbData = buildVerbDataFromSource(
   sourceConjugations as Record<string, RawConjugationEntry>
 );
 
+export const verbTranslationsEn: Record<string, string> = Object.fromEntries(
+  Object.entries(sourceConjugations as Record<string, RawConjugationEntry>)
+    .map(([verb, payload]) => [verb, payload.translation_en?.trim() ?? ""])
+    .filter(([, translation]) => translation.length > 0)
+);
+
+export function getVerbTranslationEn(verb: string): string | null {
+  return verbTranslationsEn[verb] ?? null;
+}
+
 const rules: Record<string, Record<string, string>> = {
     "Présent": {
         "er": "For regular -er verbs, drop the -er and add endings: -e, -es, -e, -ons, -ez, -ent.",


### PR DESCRIPTION
### Motivation
- Make quiz questions clearer by showing the English meaning of the target verb alongside the French infinitive in the highlighted question area.
- Use the existing `translation_en` data from the repository source rather than hardcoding translations.
- Keep the French infinitive visually primary while providing a readable secondary translation for learners on mobile and desktop.

### Description
- Added a derived `verbTranslationsEn` map and safe accessor `getVerbTranslationEn(verb)` in `src/lib/verbs.ts` that reads `translation_en` from the existing `french_conjugations.json` source.
- Updated the question header in `src/app/components/conjugation-practice.tsx` to call `getVerbTranslationEn` and render the English translation as secondary text next to the French verb when present.
- Implemented a graceful fallback so if a translation is missing the UI displays only the French infinitive and does not crash.
- Kept the change narrowly scoped to the question header and did not alter gameplay, scoring, timers, routing, or answer logic.

### Testing
- Ran TypeScript checks with `npm run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52feac3608329ad4020094b370d54)