### PR TITLE
Follow-up: standardize verb translation display formatting

### DIFF
--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -182,6 +182,13 @@ const normalizeUserConjugation = (value: string): string => {
     .trim();
 };
 
+const formatVerbTranslation = (translation: string | null): string | null => {
+  if (!translation) return null;
+  const normalized = translation.replace(/^to\s+/i, "").trim().toLowerCase();
+  if (!normalized) return null;
+  return `to ${normalized}`;
+};
+
 export function ConjugationPractice({
   onNextQuestion,
   onStatsUpdate,
@@ -1196,6 +1203,7 @@ export function ConjugationPractice({
   const currentVerbTranslation = currentQuestion
     ? getVerbTranslationEn(currentQuestion.verb)
     : null;
+  const formattedVerbTranslation = formatVerbTranslation(currentVerbTranslation);
 
   return (
     <div className="space-y-3">
@@ -1757,9 +1765,12 @@ export function ConjugationPractice({
                 }}
               >
                 {currentQuestion.verb}
-                {currentVerbTranslation ? (
-                  <span className="ml-2 text-base sm:text-lg font-semibold text-slate-500 align-middle">
-                    ({currentVerbTranslation})
+                {formattedVerbTranslation ? (
+                  <span
+                    className="mt-1 block px-2 text-sm sm:text-base font-semibold text-slate-500"
+                    style={{ overflowWrap: "anywhere", lineHeight: 1.35 }}
+                  >
+                    ({formattedVerbTranslation})
                   </span>
                 ) : null}
               </CardTitle>


### PR DESCRIPTION
### Motivation
- Make English verb translations appear consistently as `to ...` in lower-case and avoid duplicate or inconsistent prefixes from source data.
- Prevent long translations from overflowing the question card on small screens so the UI remains readable and uncluttered.

### Description
- Add `formatVerbTranslation(translation)` which trims, lowercases, removes any leading `to ` and re-adds a single `to ` prefix, returning `null` for empty values.
- Compute `formattedVerbTranslation` from `getVerbTranslationEn(currentQuestion.verb)` and render it instead of the raw translation in the question header.
- Render the translation as a wrapped secondary line under the verb and apply `overflowWrap: "anywhere"`, adjusted line-height and spacing to keep long translations inside the card.
- Keep all formatting at render time so no migration of existing translation data is required.

### Testing
- Attempted `npm run lint` but it was blocked by an interactive Next.js ESLint setup prompt and did not complete non-interactively. 
- Committed the changes successfully with message `Standardize and wrap verb translations in prompts`. 
- Created the follow-up PR describing these changes programmatically via the repository helper (PR created successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5413830e08329902669929c5f84c8)