### PR TITLE
[codex] Fix non-interactive ESLint setup

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "NODE_ENV=production next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -56,9 +56,12 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "eslint": "^9",
+    "eslint-config-next": "15.3.8",
     "genkit-cli": "^1.20.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",


### PR DESCRIPTION
## What changed

- Added a Next.js ESLint flat config in `eslint.config.mjs` using `next/core-web-vitals` and `next/typescript`.
- Updated `npm run lint` to run `eslint .` directly instead of `next lint`.
- Added the explicit ESLint dev dependencies needed by the config.

## Why

`next lint` was hitting Next.js' first-run ESLint setup prompt in non-interactive environments, so the lint command did not actually run. With a committed ESLint config and direct ESLint script, there is no setup wizard to answer.

## Validation

I verified locally in a clean checkout that `npm run lint` now starts ESLint directly instead of opening the interactive Next.js setup prompt.

The command now reaches real lint results and currently reports existing lint errors in application files, including unused variables in `src/app/components/conjugation-practice.tsx`, `src/hooks/use-toast.ts`, and a `require()` import in `tailwind.config.ts`. Those are separate from the setup prompt issue and were not changed in this PR.

## Note

I generated a matching `package-lock.json` locally, but the connector path used for this PR is best suited to small file updates. If your CI uses `npm ci`, run `npm install --package-lock-only` after merging or I can follow up with a second PR from an authenticated local GitHub CLI session that includes the lockfile update.