### PR TITLE
feat: Add Spanish i18n and language toggle (EN/ES)

### DIFF
--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/card";
 import { ArrowRight, Flame, Star, Zap } from "lucide-react";
 import { cn, formatVerbTranslation } from "@/lib/utils";
+import { type AppLanguage, t } from "@/lib/i18n";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/contexts/auth-context";
@@ -72,6 +73,7 @@ type ConjugationPracticeProps = {
   onGoHome?: () => void;
   onGameStateChange?: (state: GameState) => void;
   duelMode?: DuelMode;
+  language?: AppLanguage;
 };
 
 const TIMER_DURATION = 15;
@@ -194,6 +196,7 @@ export function ConjugationPractice({
   onGoHome,
   onGameStateChange,
   duelMode,
+  language = "en",
 }: ConjugationPracticeProps) {
   const [gameState, setGameState] = useState<GameState>(
     practiceOnly || duelMode ? "playing" : "idle"
@@ -1249,7 +1252,7 @@ export function ConjugationPractice({
           )}
           style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
         >
-          🎮 Classic
+          🎮 {t("game.classic", language)}
         </button>
         <button
           onClick={() => handleSwitchGameMode("random")}
@@ -1261,7 +1264,7 @@ export function ConjugationPractice({
           )}
           style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
         >
-          🎲 Random
+          🎲 {t("game.random", language)}
         </button>
       </div>}
 
@@ -1276,7 +1279,7 @@ export function ConjugationPractice({
             )}
             style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
           >
-            ⚡ Competitive
+            ⚡ {t("game.competitive", language)}
           </button>
           <button
             onClick={() => handleSwitchCompetitiveMode(!competitiveMode)}
@@ -1299,7 +1302,7 @@ export function ConjugationPractice({
             )}
             style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
           >
-            Casual
+            {t("game.casual", language)}
           </button>
         </div>
       )}
@@ -1379,34 +1382,32 @@ export function ConjugationPractice({
           <h2
             className="text-2xl"
             style={{
-              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              fontFamily: "’Plus Jakarta Sans’, sans-serif",
               fontWeight: 800,
               color: "#0B1020",
             }}
           >
-            Ready to streak?
+            {t("game.readyTitle", language)}
           </h2>
           <p
             className="text-sm"
             style={{
-              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              fontFamily: "’Plus Jakarta Sans’, sans-serif",
               color: "rgba(11,16,32,0.5)",
             }}
           >
-            {competitiveMode
-              ? "Answer fast. Answer right. Don’t stop."
-              : "Relax and practice. No timer, no pressure."}
+            {t("game.readySubtitle", language)}
           </p>
           <button
             onClick={handleStartStreak}
             className="w-full h-14 rounded-xl text-white font-bold text-base transition-all hover:opacity-90 active:scale-[0.98]"
             style={{
               backgroundColor: "#1F4BFF",
-              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              fontFamily: "’Plus Jakarta Sans’, sans-serif",
               fontWeight: 700,
             }}
           >
-            Start Streak →
+            {t("game.start", language)} →
           </button>
           {userStats && (
             <div className="flex justify-center gap-3 mt-3">
@@ -1454,7 +1455,7 @@ export function ConjugationPractice({
               color: "#0B1020",
             }}
           >
-            Streak broken
+            {t("game.streakBroken", language)}
           </h2>
           <p
             className="text-sm"
@@ -1590,7 +1591,7 @@ export function ConjugationPractice({
               fontWeight: 700,
             }}
           >
-            Try Again →
+            {t("game.tryAgain", language)} →
           </button>
         </div>
       )}
@@ -1819,7 +1820,7 @@ export function ConjugationPractice({
                     fontFamily: "'Plus Jakarta Sans', sans-serif",
                   }}
                 >
-                  ⏱ Time&apos;s up!
+                  ⏱ {t("game.timeExpired", language)}
                 </div>
               )}
 
@@ -1900,7 +1901,7 @@ export function ConjugationPractice({
                     value={userAnswer}
                     onChange={(e) => setUserAnswer(e.target.value)}
                     disabled={isAnswered}
-                    placeholder="Write only the conjugated verb (no pronoun)..."
+                    placeholder={t("game.typeAnswer", language)}
                     className={cn("text-center text-lg h-14", getInputClass())}
                     autoCapitalize="none"
                     autoComplete="off"
@@ -1969,7 +1970,7 @@ export function ConjugationPractice({
                   className="gap-2 animate-in fade-in-50 bg-[#FF6A4D] hover:bg-[#D95A3F] text-white"
                   style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
                 >
-                  Next <ArrowRight className="h-4 w-4" />
+                  {t("game.next", language)} <ArrowRight className="h-4 w-4" />
                 </Button>
               )}
               {/* Next after correct answer */}
@@ -1979,7 +1980,7 @@ export function ConjugationPractice({
                   className="gap-2 animate-in fade-in-50 bg-[#1F4BFF] hover:bg-[#1637CC] text-white"
                   style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
                 >
-                  Next <ArrowRight className="h-4 w-4" />
+                  {t("game.next", language)} <ArrowRight className="h-4 w-4" />
                 </Button>
               )}
               {/* Next in practiceOnly or duelMode wrong answer */}
@@ -1989,7 +1990,7 @@ export function ConjugationPractice({
                   className="gap-2 animate-in fade-in-50 bg-[#FF6A4D] hover:bg-[#D95A3F] text-white"
                   style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
                 >
-                  Next <ArrowRight className="h-4 w-4" />
+                  {t("game.next", language)} <ArrowRight className="h-4 w-4" />
                 </Button>
               )}
             </CardFooter>

--- a/src/app/components/felicitations.tsx
+++ b/src/app/components/felicitations.tsx
@@ -3,10 +3,12 @@
 
 import React, { useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
+import { type AppLanguage, t } from "@/lib/i18n";
 
 type FelicitationsProps = {
   type: "personal" | "global";
   onDismiss: () => void;
+  language?: AppLanguage;
 };
 
 // Confetti piece definition
@@ -40,7 +42,7 @@ function generateConfetti(): ConfettiPiece[] {
   return pieces;
 }
 
-export function Felicitations({ type, onDismiss }: FelicitationsProps) {
+export function Felicitations({ type, onDismiss, language = "en" }: FelicitationsProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const confetti = useMemo(() => generateConfetti(), []);
 
@@ -106,15 +108,15 @@ export function Felicitations({ type, onDismiss }: FelicitationsProps) {
           style={{ color: "#0B1020", opacity: 0.7 }}
         >
           {type === "global"
-            ? "You're the new #1 on the leaderboard!"
-            : "You just set a new personal best streak!"}
+            ? (language === "es" ? "¡Eres el nuevo #1 en la tabla de posiciones!" : "You're the new #1 on the leaderboard!")
+            : (language === "es" ? "¡Acabas de establecer un nuevo récord personal!" : "You just set a new personal best streak!")}
         </p>
         <Button
           onClick={onDismiss}
           className="w-full font-semibold text-white"
           style={{ backgroundColor: "#1F4BFF" }}
         >
-          Keep Going 🔥
+          {language === "es" ? "¡Seguir! 🔥" : "Keep Going 🔥"}
         </Button>
       </div>
     </div>

--- a/src/app/components/leaderboard.tsx
+++ b/src/app/components/leaderboard.tsx
@@ -16,10 +16,12 @@ import { Badge } from "@/components/ui/badge";
 import { Flame, Target, Calendar, Trophy, User, Shuffle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { PlayerStatsDialog } from "@/app/components/player-stats-dialog";
+import { type AppLanguage, t } from "@/lib/i18n";
 
 type LeaderboardProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  language?: AppLanguage;
 };
 
 const podiumColors = [
@@ -124,7 +126,7 @@ function LeaderboardList({
   );
 }
 
-export function Leaderboard({ open, onOpenChange }: LeaderboardProps) {
+export function Leaderboard({ open, onOpenChange, language = "en" }: LeaderboardProps) {
   const { user } = useAuth();
   const [classicBoard, setClassicBoard] = useState<LeaderboardEntry[]>([]);
   const [randomBoard, setRandomBoard] = useState<LeaderboardEntry[]>([]);
@@ -171,7 +173,7 @@ export function Leaderboard({ open, onOpenChange }: LeaderboardProps) {
             style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
           >
             <Trophy className="h-5 w-5 text-[#FF6A4D]" />
-            Leaderboard
+            {t("leaderboard.title", language)}
           </DialogTitle>
         </DialogHeader>
 
@@ -188,7 +190,7 @@ export function Leaderboard({ open, onOpenChange }: LeaderboardProps) {
                 title="Best Classic Streak — longest streak in Classic Mode (same verb, all pronouns)"
                 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
               >
-                <Flame className="h-3 w-3" /> Classic
+                <Flame className="h-3 w-3" /> {t("leaderboard.classic", language)}
               </TabsTrigger>
               <TabsTrigger
                 value="random"
@@ -196,7 +198,7 @@ export function Leaderboard({ open, onOpenChange }: LeaderboardProps) {
                 title="Best Random Streak — longest streak in Random Mode (fully random verb + tense + pronoun)"
                 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
               >
-                <Shuffle className="h-3 w-3" /> Random
+                <Shuffle className="h-3 w-3" /> {t("leaderboard.random", language)}
               </TabsTrigger>
               <TabsTrigger
                 value="correct"
@@ -204,7 +206,7 @@ export function Leaderboard({ open, onOpenChange }: LeaderboardProps) {
                 title="Total Correct — all-time correct answers across both modes"
                 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
               >
-                <Target className="h-3 w-3" /> All-Time
+                <Target className="h-3 w-3" /> {t("leaderboard.allTime", language)}
               </TabsTrigger>
               <TabsTrigger
                 value="daily"
@@ -212,7 +214,7 @@ export function Leaderboard({ open, onOpenChange }: LeaderboardProps) {
                 title="Daily Streak — consecutive days you've practiced"
                 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
               >
-                <Calendar className="h-3 w-3" /> Daily
+                <Calendar className="h-3 w-3" /> {t("leaderboard.daily", language)}
               </TabsTrigger>
             </TabsList>
 

--- a/src/app/components/onboarding.tsx
+++ b/src/app/components/onboarding.tsx
@@ -5,10 +5,12 @@ import React from "react";
 import { useAuth } from "@/contexts/auth-context";
 import { Button } from "@/components/ui/button";
 import { LogIn, ArrowRight } from "lucide-react";
+import { type AppLanguage, t } from "@/lib/i18n";
 
 type OnboardingProps = {
   onClose: () => void;
   onOpenStudy?: () => void;
+  language?: AppLanguage;
 };
 
 const HOW_TO_PLAY = [
@@ -39,7 +41,7 @@ const HOW_TO_PLAY = [
   },
 ];
 
-export function Onboarding({ onClose, onOpenStudy }: OnboardingProps) {
+export function Onboarding({ onClose, onOpenStudy, language = "en" }: OnboardingProps) {
   const { signInWithGoogle } = useAuth();
 
   const handleSignIn = async () => {
@@ -148,7 +150,7 @@ export function Onboarding({ onClose, onOpenStudy }: OnboardingProps) {
               }}
             >
               <LogIn className="h-4 w-4" />
-              Sign in with Google
+              {t("user.signIn", language)} with Google
             </Button>
             <Button
               onClick={onClose}
@@ -156,7 +158,7 @@ export function Onboarding({ onClose, onOpenStudy }: OnboardingProps) {
               className="w-full gap-2 text-gray-600 hover:text-gray-900"
               style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
             >
-              Play as Guest
+              {t("onboarding.continue", language)}
               <ArrowRight className="h-4 w-4" />
             </Button>
             {onOpenStudy && (
@@ -166,7 +168,7 @@ export function Onboarding({ onClose, onOpenStudy }: OnboardingProps) {
                 className="w-full gap-2 font-semibold text-gray-700 border-gray-300 hover:border-[#1F4BFF] hover:text-[#1F4BFF]"
                 style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontWeight: 600, fontSize: "0.875rem" }}
               >
-                📖 Study Mode
+                📖 {t("study.title", language)}
               </Button>
             )}
           </div>

--- a/src/app/components/study-mode.tsx
+++ b/src/app/components/study-mode.tsx
@@ -17,10 +17,12 @@ import {
 } from "@/components/ui/accordion";
 import { ConjugationPractice } from "@/app/components/conjugation-practice";
 import { getRule } from "@/lib/verbs";
+import { type AppLanguage, t } from "@/lib/i18n";
 
 type StudyModeProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  language?: AppLanguage;
 };
 
 type TenseInfo = {
@@ -163,7 +165,7 @@ function RulesTab() {
   );
 }
 
-export function StudyMode({ open, onOpenChange }: StudyModeProps) {
+export function StudyMode({ open, onOpenChange, language = "en" }: StudyModeProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -175,7 +177,7 @@ export function StudyMode({ open, onOpenChange }: StudyModeProps) {
             className="text-xl font-extrabold"
             style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", color: "#0B1020" }}
           >
-            📖 Study Mode
+            📖 {t("study.title", language)}
           </DialogTitle>
         </DialogHeader>
 
@@ -193,7 +195,7 @@ export function StudyMode({ open, onOpenChange }: StudyModeProps) {
               className="flex-1 text-xs font-semibold data-[state=active]:bg-[#1F4BFF] data-[state=active]:text-white"
               style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
             >
-              🎮 Practice
+              🎮 {t("study.practiceOnly", language)}
             </TabsTrigger>
           </TabsList>
 
@@ -217,6 +219,7 @@ export function StudyMode({ open, onOpenChange }: StudyModeProps) {
               <ConjugationPractice
                 onNextQuestion={() => {}}
                 practiceOnly={true}
+                language={language}
               />
             </div>
           </TabsContent>

--- a/src/app/components/user-menu.tsx
+++ b/src/app/components/user-menu.tsx
@@ -27,6 +27,7 @@ import {
   Check,
 } from "lucide-react";
 import { buildWhatsAppInvite } from "@/lib/utils";
+import { type AppLanguage, t } from "@/lib/i18n";
 
 type ActiveScreen = "home" | "leaderboard" | "study" | "help";
 
@@ -40,6 +41,8 @@ type UserMenuProps = {
   friendsPanelOpen?: boolean;
   setFriendsPanelOpen?: (open: boolean) => void;
   pendingRequestCount?: number;
+  language?: AppLanguage;
+  onLanguageChange?: (lang: AppLanguage) => void;
 };
 
 const handleChallengeFriend = () => {
@@ -59,6 +62,8 @@ export function UserMenu({
   friendsPanelOpen = false,
   setFriendsPanelOpen,
   pendingRequestCount = 0,
+  language = "en",
+  onLanguageChange,
 }: UserMenuProps) {
   const { user, signInWithGoogle, signOut, isGuest, loading } = useAuth();
   const [copied, setCopied] = useState(false);
@@ -144,6 +149,40 @@ export function UserMenu({
           )}
         </div>
       )}
+
+      {/* Language switcher — compact EN/ES toggle */}
+      {onLanguageChange && (
+        <div
+          className="flex items-center rounded-full overflow-hidden"
+          style={{ border: "1px solid rgba(255,255,255,0.2)" }}
+          aria-label={t("language.label", language)}
+        >
+          <button
+            onClick={() => onLanguageChange("en")}
+            className="px-2 py-1 text-[11px] font-bold transition-colors"
+            style={{
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              backgroundColor: language === "en" ? "#1F4BFF" : "transparent",
+              color: language === "en" ? "#FFFFFF" : "rgba(255,255,255,0.45)",
+            }}
+            aria-label={t("language.english", language)}
+          >
+            EN
+          </button>
+          <button
+            onClick={() => onLanguageChange("es")}
+            className="px-2 py-1 text-[11px] font-bold transition-colors"
+            style={{
+              fontFamily: "'Plus Jakarta Sans', sans-serif",
+              backgroundColor: language === "es" ? "#1F4BFF" : "transparent",
+              color: language === "es" ? "#FFFFFF" : "rgba(255,255,255,0.45)",
+            }}
+            aria-label={t("language.spanish", language)}
+          >
+            ES
+          </button>
+        </div>
+      )}
     </div>
   );
 
@@ -155,8 +194,8 @@ export function UserMenu({
         top: "calc(env(safe-area-inset-top, 0px) + 12px)",
         right: "calc(env(safe-area-inset-right, 0px) + 12px)",
       }}
-      title="Sign in with Google"
-      aria-label="Sign in with Google"
+      title={t("user.signIn", language)}
+      aria-label={t("user.signIn", language)}
     >
       <LogIn size={20} />
     </button>
@@ -236,7 +275,7 @@ export function UserMenu({
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={onShowLeaderboard}>
           <Trophy className="mr-2 h-4 w-4" />
-          Leaderboard
+          {t("leaderboard.title", language)}
         </DropdownMenuItem>
         {onShowOnboarding && (
           <DropdownMenuItem onClick={onShowOnboarding}>
@@ -247,7 +286,7 @@ export function UserMenu({
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={signOut}>
           <LogOut className="mr-2 h-4 w-4" />
-          Sign out
+          {t("user.signOut", language)}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,8 @@ import { FriendsPanel } from "@/app/components/friends-panel";
 import { SplashScreen } from "@/app/components/splash-screen";
 import { useAuth } from "@/contexts/auth-context";
 import { useState, useEffect, useCallback } from "react";
-import { initializeUserStats, submitDuelScore, type UserStats } from "@/lib/firestore";
+import { initializeUserStats, submitDuelScore, updatePreferredLanguage, type UserStats } from "@/lib/firestore";
+import { type AppLanguage, LANGUAGE_STORAGE_KEY, t } from "@/lib/i18n";
 import { collection, query, where, onSnapshot } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { Heart } from "lucide-react";
@@ -32,7 +33,27 @@ export default function Home() {
   const [currentGameState, setCurrentGameState] = useState<"idle" | "playing" | "lost">("idle");
   const [duelMode, setDuelMode] = useState<{ duelId: string; verbSeed: number; mode?: "classic" | "random" } | null>(null);
   const [duelResultMessage, setDuelResultMessage] = useState("");
+  const [language, setLanguage] = useState<AppLanguage>("en");
   const { user, loading, friendCode } = useAuth();
+
+  // Read language preference from localStorage on mount
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+    if (stored === "en" || stored === "es") {
+      setLanguage(stored);
+    }
+  }, []);
+
+  const handleLanguageChange = useCallback((lang: AppLanguage) => {
+    setLanguage(lang);
+    if (typeof window !== "undefined") {
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, lang);
+    }
+    if (user) {
+      updatePreferredLanguage(user.uid, lang).catch(console.error);
+    }
+  }, [user]);
 
   // Manage onboarding visibility and user stats based on auth state
   useEffect(() => {
@@ -48,6 +69,16 @@ export default function Home() {
         user.photoURL
       ).then((stats) => {
         setUserStats(stats);
+        if (stats.preferredLanguage) {
+          setLanguage(stats.preferredLanguage);
+          if (typeof window !== "undefined") {
+            localStorage.setItem(LANGUAGE_STORAGE_KEY, stats.preferredLanguage);
+          }
+        } else {
+          const storedLang = typeof window !== "undefined" ? localStorage.getItem(LANGUAGE_STORAGE_KEY) : null;
+          const langToSave: AppLanguage = (storedLang === "en" || storedLang === "es") ? storedLang : "en";
+          updatePreferredLanguage(user.uid, langToSave).catch(console.error);
+        }
       });
     } else {
       setUserStats(null);
@@ -222,7 +253,7 @@ export default function Home() {
               opacity: 0.6,
             }}
           >
-            LEARN AND COMPETE
+            {t("app.tagline", language)}
           </p>
         </header>
 
@@ -238,6 +269,8 @@ export default function Home() {
             friendsPanelOpen={friendsPanelOpen}
             setFriendsPanelOpen={setFriendsPanelOpen}
             pendingRequestCount={pendingRequestCount}
+            language={language}
+            onLanguageChange={handleLanguageChange}
           />
         </div>
       </div>
@@ -254,6 +287,7 @@ export default function Home() {
             onHomeInterruptDismiss={() => setShowHomeInterrupt(false)}
             onGoHome={() => setShowHomeInterrupt(false)}
             onGameStateChange={setCurrentGameState}
+            language={language}
             duelMode={duelMode ? {
               duelId: duelMode.duelId,
               verbSeed: duelMode.verbSeed,
@@ -314,24 +348,26 @@ export default function Home() {
       )}
 
       {/* Leaderboard modal */}
-      <Leaderboard open={showLeaderboard} onOpenChange={setShowLeaderboard} />
+      <Leaderboard open={showLeaderboard} onOpenChange={setShowLeaderboard} language={language} />
 
       {/* Onboarding overlay */}
       {showOnboarding && (
         <Onboarding
           onClose={() => setShowOnboarding(false)}
           onOpenStudy={handleOpenStudy}
+          language={language}
         />
       )}
 
       {/* Study Mode modal */}
-      <StudyMode open={showStudyMode} onOpenChange={setShowStudyMode} />
+      <StudyMode open={showStudyMode} onOpenChange={setShowStudyMode} language={language} />
 
       {/* Félicitations overlay */}
       {felicitationsType && (
         <Felicitations
           type={felicitationsType}
           onDismiss={handleDismissFelicitations}
+          language={language}
         />
       )}
     </main>

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -76,6 +76,9 @@ export type UserStats = {
   // Friend code system
   friendCode?: string;
   friendCount?: number;
+
+  // UI preference
+  preferredLanguage?: "en" | "es";
 };
 
 export type Friendship = {
@@ -138,6 +141,13 @@ export async function initializeUserStats(
   }, { merge: true });
 
   return newStats;
+}
+
+export async function updatePreferredLanguage(
+  uid: string,
+  language: "en" | "es"
+): Promise<void> {
+  await updateDoc(getUserRef(uid), { preferredLanguage: language });
 }
 
 export async function recordAnswer(

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,114 @@
+// src/lib/i18n.ts
+
+export type AppLanguage = "en" | "es";
+
+export const LANGUAGE_STORAGE_KEY = "vf_language";
+
+type TranslationKey =
+  | "app.tagline"
+  | "game.readyTitle"
+  | "game.readySubtitle"
+  | "game.start"
+  | "game.tryAgain"
+  | "game.streakBroken"
+  | "game.correct"
+  | "game.wrong"
+  | "game.next"
+  | "game.typeAnswer"
+  | "game.chooseAnswer"
+  | "game.timeExpired"
+  | "game.casual"
+  | "game.competitive"
+  | "game.classic"
+  | "game.random"
+  | "leaderboard.title"
+  | "leaderboard.classic"
+  | "leaderboard.random"
+  | "leaderboard.allTime"
+  | "leaderboard.daily"
+  | "onboarding.title"
+  | "onboarding.subtitle"
+  | "onboarding.continue"
+  | "study.title"
+  | "study.subtitle"
+  | "study.practiceOnly"
+  | "user.signIn"
+  | "user.signOut"
+  | "language.label"
+  | "language.english"
+  | "language.spanish";
+
+const translations: Record<AppLanguage, Record<TranslationKey, string>> = {
+  en: {
+    "app.tagline": "LEARN AND COMPETE",
+    "game.readyTitle": "Ready to streak?",
+    "game.readySubtitle": "Conjugate fast. Stay sharp. Climb the board.",
+    "game.start": "Start",
+    "game.tryAgain": "Try Again",
+    "game.streakBroken": "Streak broken.",
+    "game.correct": "Correct",
+    "game.wrong": "Wrong",
+    "game.next": "Next",
+    "game.typeAnswer": "Type your answer",
+    "game.chooseAnswer": "Choose the correct answer",
+    "game.timeExpired": "Time expired",
+    "game.casual": "Casual",
+    "game.competitive": "Competitive",
+    "game.classic": "Classic",
+    "game.random": "Random",
+    "leaderboard.title": "Leaderboard",
+    "leaderboard.classic": "Classic",
+    "leaderboard.random": "Random",
+    "leaderboard.allTime": "All-Time",
+    "leaderboard.daily": "Daily",
+    "onboarding.title": "Welcome to VerbumFlow",
+    "onboarding.subtitle": "Practice French verbs through speed, streaks, and focus.",
+    "onboarding.continue": "Continue",
+    "study.title": "Study Mode",
+    "study.subtitle": "Practice without timers, streaks, or pressure.",
+    "study.practiceOnly": "Practice only",
+    "user.signIn": "Sign in",
+    "user.signOut": "Sign out",
+    "language.label": "Language",
+    "language.english": "English",
+    "language.spanish": "Spanish",
+  },
+  es: {
+    "app.tagline": "APRENDE Y COMPITE",
+    "game.readyTitle": "¿Listo para tu racha?",
+    "game.readySubtitle": "Conjuga rápido. Mantente preciso. Sube en la tabla.",
+    "game.start": "Empezar",
+    "game.tryAgain": "Intentar de nuevo",
+    "game.streakBroken": "Racha perdida.",
+    "game.correct": "Correcto",
+    "game.wrong": "Incorrecto",
+    "game.next": "Siguiente",
+    "game.typeAnswer": "Escribe tu respuesta",
+    "game.chooseAnswer": "Elige la respuesta correcta",
+    "game.timeExpired": "Se acabó el tiempo",
+    "game.casual": "Casual",
+    "game.competitive": "Competitivo",
+    "game.classic": "Clásico",
+    "game.random": "Aleatorio",
+    "leaderboard.title": "Tabla de posiciones",
+    "leaderboard.classic": "Clásico",
+    "leaderboard.random": "Aleatorio",
+    "leaderboard.allTime": "Histórico",
+    "leaderboard.daily": "Diario",
+    "onboarding.title": "Bienvenido a VerbumFlow",
+    "onboarding.subtitle": "Practica verbos en francés con velocidad, rachas y enfoque.",
+    "onboarding.continue": "Continuar",
+    "study.title": "Modo de estudio",
+    "study.subtitle": "Practica sin temporizador, rachas ni presión.",
+    "study.practiceOnly": "Solo práctica",
+    "user.signIn": "Iniciar sesión",
+    "user.signOut": "Cerrar sesión",
+    "language.label": "Idioma",
+    "language.english": "Inglés",
+    "language.spanish": "Español",
+  },
+};
+
+export function t(key: TranslationKey, language: AppLanguage): string {
+  return translations[language][key];
+}


### PR DESCRIPTION
Implements issue #85 — Spanish i18n system with EN/ES language switcher.

**Changes:**
- New `src/lib/i18n.ts` with `AppLanguage` type, translation dictionary, and `t()` helper
- `preferredLanguage` field added to Firestore `UserStats` type
- Language state in `page.tsx`: localStorage for guests, Firestore for signed-in users
- Compact EN/ES toggle in the nav bar (visible to all users)
- `language` prop threaded through: ConjugationPractice, Leaderboard, Onboarding, UserMenu, Felicitations, StudyMode
- All game flow, scoring, streak logic, and French verb content unchanged

Closes #85

Generated with [Claude Code](https://claude.ai/code)