### PR TITLE
Follow-up: wire conjugation verb meaning to localized translation shape

### DIFF
--- a/src/app/components/conjugation-practice.tsx
+++ b/src/app/components/conjugation-practice.tsx
@@ -7,7 +7,7 @@ import {
   verbs as allVerbs,
   allConjugations,
   getRule,
-  getVerbTranslationEn,
+  getVerbTranslation,
 } from "@/lib/verbs";
 import { Button } from "@/components/ui/button";
 import {
@@ -1198,12 +1198,12 @@ export function ConjugationPractice({
   // Determine which input mode to show (force multiple-choice in practiceOnly and duelMode)
   const displayMode: PracticeMode = practiceOnly || duelMode ? "multiple-choice" : mode;
   const currentVerbTranslation = currentQuestion
-    ? getVerbTranslationEn(currentQuestion.verb)
+    ? getVerbTranslation(currentQuestion.verb)
     : null;
-  if (process.env.NODE_ENV !== "production" && currentQuestion && !currentVerbTranslation) {
-    console.warn(`Missing English translation for verb: ${currentQuestion.verb}`);
+  if (process.env.NODE_ENV !== "production" && currentQuestion && !currentVerbTranslation?.[language]) {
+    console.warn(`Missing ${language.toUpperCase()} translation for verb: ${currentQuestion.verb}`);
   }
-  const formattedVerbTranslation = formatVerbTranslation(currentVerbTranslation);
+  const formattedVerbTranslation = formatVerbTranslation(currentVerbTranslation, language);
 
   return (
     <div className="space-y-3">
@@ -1476,7 +1476,7 @@ export function ConjugationPractice({
                 color: "rgba(11,16,32,0.7)",
               }}
             >
-              {lossVerb} ({formatVerbTranslation(getVerbTranslationEn(lossVerb))})
+              {lossVerb} ({formatVerbTranslation(getVerbTranslation(lossVerb), language)})
               {' · '}
               {lossTense}
             </p>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,9 +24,24 @@ export function buildWhatsAppInvite(friendCode: string): string {
   return `https://wa.me/?text=${message}`;
 }
 
-export function formatVerbTranslation(translation?: string | null): string {
+import { type AppLanguage } from "@/lib/i18n";
+import { type LocalizedTranslation } from "@/lib/verbs";
+
+export function formatVerbTranslation(
+  translation: LocalizedTranslation | string | undefined | null,
+  language: AppLanguage
+): string {
   if (!translation) return "translation unavailable";
-  const clean = translation.trim();
-  if (clean.toLowerCase().startsWith("to ")) return clean;
-  return `to ${clean}`;
+
+  const raw = typeof translation === "string" ? translation : translation[language];
+  if (!raw) return "translation unavailable";
+
+  const clean = raw.trim();
+  if (!clean) return "translation unavailable";
+
+  if (language === "en") {
+    return clean.toLowerCase().startsWith("to ") ? clean : `to ${clean}`;
+  }
+
+  return clean;
 }

--- a/src/lib/verbs.ts
+++ b/src/lib/verbs.ts
@@ -12,7 +12,13 @@ export type VerbData = {
 
 type RawConjugationEntry = {
   translation_en?: string;
+  translation_es?: string;
   moods?: Record<string, Record<string, string>>;
+};
+
+export type LocalizedTranslation = {
+  en: string;
+  es: string;
 };
 
 const SOURCE_TO_APP_TENSE: Record<string, string> = {
@@ -105,14 +111,18 @@ export const verbData: VerbData = buildVerbDataFromSource(
   sourceConjugations as Record<string, RawConjugationEntry>
 );
 
-export const verbTranslationsEn: Record<string, string> = Object.fromEntries(
-  Object.entries(sourceConjugations as Record<string, RawConjugationEntry>)
-    .map(([verb, payload]) => [verb, payload.translation_en?.trim() ?? ""])
-    .filter(([, translation]) => translation.length > 0)
+export const verbTranslations: Record<string, LocalizedTranslation> = Object.fromEntries(
+  Object.entries(sourceConjugations as Record<string, RawConjugationEntry>).map(([verb, payload]) => [
+    verb,
+    {
+      en: payload.translation_en?.trim() ?? "",
+      es: payload.translation_es?.trim() ?? "",
+    },
+  ])
 );
 
-export function getVerbTranslationEn(verb: string): string | null {
-  return verbTranslationsEn[verb] ?? null;
+export function getVerbTranslation(verb: string): LocalizedTranslation | null {
+  return verbTranslations[verb] ?? null;
 }
 
 const rules: Record<string, Record<string, string>> = {


### PR DESCRIPTION
### Motivation
- Make verb meaning display language-aware so the app shows verb meanings in the selected `en`/`es` language while leaving all French conjugation data unchanged. 
- Ensure English meanings are normalized to include the `to ` prefix and Spanish meanings are returned as-is, with a clear fallback of `translation unavailable` when missing. 
- Keep existing game, scoring, streak, and timing logic untouched while enabling UI-level localization for verb meanings.

### Description
- Extended `src/lib/verbs.ts` to accept optional `translation_es`, added the `LocalizedTranslation` type, and replaced the English-only map with `verbTranslations` plus `getVerbTranslation()` returning `{ en, es }`. 
- Reworked `src/lib/utils.ts` `formatVerbTranslation(...)` to accept a localized translation and an `AppLanguage` and implement the `to ` prefix rule for English, Spanish-as-is behavior, and the `translation unavailable` fallback. 
- Updated `src/app/components/conjugation-practice.tsx` to use `getVerbTranslation(...)`, call `formatVerbTranslation(..., language)` for presentation in the main prompt and loss overlay, and emit a dev-time warning when the active language translation is missing. 

### Testing
- Ran `npm run build` and the Next.js production build completed successfully. 
- Ran `npm run lint` which failed in this environment due to a missing local dependency (`@eslint/eslintrc`), not due to the code changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f59159b69c83299590ab9cabda5b4c)